### PR TITLE
memacs-mumail fixes

### DIFF
--- a/bin/memacs_mumail.py
+++ b/bin/memacs_mumail.py
@@ -3,9 +3,6 @@
 # Time-stamp: <2015-04-30 17:12:02 vs>
 
 from memacs.mu import MuMail
-import locale
-
-locale.setlocale(locale.LC_ALL,'de_DE.utf-8')
 
 PROG_VERSION_NUMBER = u"0.1"
 PROG_VERSION_DATE = u"2015-03-08"
@@ -18,7 +15,6 @@ CONFIG_PARSER_NAME = ""
 COPYRIGHT_YEAR = "2011-2015"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Stephanus Volke <post@stephanus-volke.de>"""
-
 
 if __name__ == "__main__":
     

--- a/docs/memacs_mumail.org
+++ b/docs/memacs_mumail.org
@@ -1,33 +1,29 @@
-## Time-stamp: <2015-05-05 Di 14:05 matthias>
-## This file is best viewed with GNU Emacs Org-mode: http://orgmode.org/
+#  -*- mode: org -*-
+# This file is best viewed with GNU Emacs Org-mode: http://orgmode.org/
+#+TITLE: memacs-mumail
 
-* memacs-mumail
+* Current status
 
-** Current status
+Experimental. Please report any problems you find opening a new issue
+or writing an email to [[mailto:memacs-mumail@m.stennes.org][memacs-mumail@m.stennes.org]]
 
-Experimental. Please report any problems you find opening a new issue or writing a
-mail to [[mailto:memacs-mumail@m.stennes.org][memacs-mumail@m.stennes.org]]
+* Data Source
 
-
-** Data Source
-This memacs module will parse your mails after they are indexed by [[http://www.djcbsoftware.nl/code/mu/][mu]].
-Clickable links have just been tested with [[http://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]] (an emacs-based e-mail client based
-on mu) as frontend.
+This memacs module will parse your emails after they are indexed by
+[[http://www.djcbsoftware.nl/code/mu/][mu]].  Clickable links have just been tested with [[http://www.djcbsoftware.nl/code/mu/mu4e.html][mu4e]] (an emacs-based
+e-mail client based on mu) as frontend.
 
 Look [[https://gist.github.com/areina/3879626][here]] for how to set up mu4e with offlineimap.
 
-** Example Invocation
+* Example Invocation
+** Basic Invocation
 
-*** Basic Invocation
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "you@domain.org"
 
+The -m param with your email address will check if the mail ewas from
+or to you.
 
-: $ /path/to/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "you@domain.org"
-
-
-
-The -m param with your emailaddress will check if the mail was from or to you.
-
-An entry with a mail from you will look like this:
+An entry with an email from you will look like this:
 
 : ** <2011-11-03 Do 13:31> F: [[mailto:sender@domain.org][Sender Name]]: [[mu4e:msgid:1554232683.7822665.1320323516478.JavaMail.fmail@mwmweb024][subject]]
 :   :PROPERTIES:
@@ -36,7 +32,7 @@ An entry with a mail from you will look like this:
 :   :ID:         638a689e6e40abe4f3ae1da6834da42f44082577
 :   :END:
 
-An entry with a mail to you will look like this
+An entry with an email to you will look like this
 
 : ** <2012-07-05 Do 21:21> T: [[mailto:recipient@domain.org][Recipient Name]]: [[mu4e:msgid:3EDBEB35-D9CA-4A10-8582-A98A65B30097@arcor.de][Re: subject]]
 :   :PROPERTIES:
@@ -45,38 +41,36 @@ An entry with a mail to you will look like this
 :   :ID:         591a0dcf4bf83c8b508324c7c954d2e7b1a0b822
 :   :END:
 
+** Advanced Invocation
 
-*** Advanced Invocation
+You can use the -q param with every input for mu find that is
+supported by mu. Check out [[http://www.djcbsoftware.nl/code/mu/cheatsheet.html][Mu Cheatsheet]] and [[http://manpages.ubuntu.com/manpages/lucid/man1/mu-find.1.html][ubuntu manuals mu]].
 
-You can use the -q param with every input for mu find that is supported by mu.
-Check out [[http://www.djcbsoftware.nl/code/mu/cheatsheet.html][Mu Cheatsheet]] and  [[http://manpages.ubuntu.com/manpages/lucid/man1/mu-find.1.html][ubuntu manuals mu]].
+*** Unread emails
 
-**** Unread  mails
+For people using the agenda a lot, it could be nice to see new
+(unread) emails directly on the agenda. The following invocation will
+list just all unread mails in your Maildir
 
-For people using the agenda a lot, it could be nice to see new (unread) mails
-directly on the agenda.
-The following invocation will list just all unread mails in your Maildir
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:unread" -m "you@domain.org" 
 
-: $ /path/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:unread" -m "you@domain.org" 
+To see the emails on your agenda add the -o param and include the
+selected .org-file (not .org_archive) to your org-agenda-files.
 
-To see the mails on your agenda add the -o param and include the selected file
-.org file (not .org_archive) to your org-agenda-files. 
+*** Flagged emails
 
+Do you know this: You check your mails on the road, but you do not
+have time to reply and when you are at home you forget it?
 
-**** Flagged mails
+With this option flagged mails will appear on your agenda:
 
-Do you know this: 
-You check your mails on the road, but you do not have time to reply and when you
-are at home you forget it?
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:flagged" -m "you@domain.org -d"
 
-With this option flagged mails will  appear on your agenda:
+If you add the param -d, messages in your INBOX that are flagged will
+be marked as NEXT and messages in your Sent folder will be marked as
+WAITING.
 
-: $ /path/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:flagged" -m "you@domain.org -d"
-
-If you add the param -d, messages in your INBOX that are flagged will be marked as NEXT
-and messages in Your Sent folder will be marked as WAITING.
-
-Entry for a flagged mail in your inbox
+Entry for a flagged email in your INBOX
 
 : ** NEXT <2011-11-03 Do 13:31> F: [[mailto:sender@domain.org][Sender Name]]: [[mu4e:msgid:1554232683.7822665.1320323516478.JavaMail.fmail@mwmweb024][subject]]
 :   SCHEDULED: <2011-11-03 Do>
@@ -86,8 +80,7 @@ Entry for a flagged mail in your inbox
 :   :ID:         638a689e6e40abe4f3ae1da6834da42f44082577
 :   :END:
 
-
-Entry for a flagged mail in your sent folder
+Entry for a flagged email in your Sent folder
 
 : ** WAITING <2012-07-05 Do 21:21> T: [[mailto:recipient@domain.org][Recipient Name]]: [[mu4e:msgid:3EDBEB35-D9CA-4A10-8582-A98A65B30097@arcor.de][Re: subject]]
 :   SCHEDULED: <2012-07-05 Do>
@@ -97,25 +90,24 @@ Entry for a flagged mail in your sent folder
 :   :ID:         591a0dcf4bf83c8b508324c7c954d2e7b1a0b822
 :   :END:
 
-To see the mails on your agenda add the -o param and include the selected file
-.org file (not .org_archive) to your org-agenda-files. 
+To see the emails on your agenda, add the -o param and include the
+selected .org-file (not .org_archive) to your org-agenda-files.
 
+To get both unread and flagged emails use the following invocation
 
-To get both unread and flagged mails use the following Invocation
-: $ /path/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:flagged or maildir:'/YourMaildir' and flag:unread " -m "you@domain.org"
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir' and flag:flagged or maildir:'/YourMaildir' and flag:unread " -m "you@domain.org"
 
+*** Using a catch-all domain
 
-**** Using a catchall domain
+When you are using a catch-all domain, you can use the following
+invocation to check whether the email was sent from or to you.
 
-When you are using a catch all domain, you can use the following invocation
-to check whether the mail was sent from or to you.
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "@domain.org" 
 
-: $ /path/to/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "@domain.org" 
+For the case that you are using a catch-all domain (e.g. as subdomain)
+and another address at the same time you can use:
 
-For the Case that you are using a catch all domain (e.g. as subdomain) and
-another address at the same time you can use:
-
-: $ /path/to/Memacs/bin/memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "you@domain.org @sub.domain.org" 
+: $ memacs_mumail.py -q "mu find maildir:'/YourMaildir'" -m "you@domain.org @sub.domain.org" 
 
 
 

--- a/memacs/mu.py
+++ b/memacs/mu.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import subprocess
 from datetime import datetime
 from lib.orgproperty import OrgProperties
 from lib.orgformat import OrgFormat
 from lib.memacs import Memacs
 import re
-import locale
 
 class MuMail(Memacs):
         
@@ -68,7 +68,7 @@ class MuMail(Memacs):
         """
         time = time.strip().encode('utf-8')
 
-        mail_date = datetime.strptime(time,"%a %d %b %H:%M:%S %Y")
+        mail_date = datetime.strptime(time,"%c")
         if onlyDate is False:
             return OrgFormat.datetime(mail_date)
         return OrgFormat.date(mail_date)
@@ -129,5 +129,3 @@ class MuMail(Memacs):
                     timestamp = ""
                     output = pre+output
             self._writer.write_org_subitem(timestamp, output, notes, properties)
-
-


### PR DESCRIPTION
Hi there,

- fixes to make memacs-mumail work with a non-de_DE locale such as en_US by putting the correct argument into the strptime call
- documentation fixes: spelling, grammar, wrap long lines

Cheers,
Daniel