### PR TITLE
Properties drawers syntax changes

### DIFF
--- a/memacs/lib/orgwriter.py
+++ b/memacs/lib/orgwriter.py
@@ -159,14 +159,14 @@ class OrgOutputWriter(object):
         timestamp = timestamp.strip()
 
         self.writeln(u"** " + timestamp + u" " + output + output_tags)
-        if note != "":
-            for n in note.splitlines():
-                self.writeln("   " + n)
         self.writeln(unicode(properties))
         if self.__test:
             self.write(properties.get_multiline_properties())
         else:
             self.writeln(properties.get_multiline_properties())
+        if note != "":
+            for n in note.splitlines():
+                self.writeln("   " + n)
 
     def write_org_subitem(self,
                           timestamp,


### PR DESCRIPTION
According [to the changelog](http://orgmode.org/Changes.html) of orgmode version 8.3:

> Properties drawers are now required to be located **right after a headline** and its planning line, when applicable. It will break some documents as TODO states changes were sometimes logged before the property drawer.