### PR TITLE
fix writing entry twice

### DIFF
--- a/memacs/filenametimestamps.py
+++ b/memacs/filenametimestamps.py
@@ -175,7 +175,7 @@ class FileNameTimeStamps(Memacs):
 
             self.__write_file(file, link, orgdate)
 
-        if DATESTAMP_REGEX.match(file):
+        elif DATESTAMP_REGEX.match(file):
             try:
                 # we put this in a try block because:
                 # if a timestamp is false i.e. 2011-14-19 or false time


### PR DESCRIPTION
While using the new option `--force-file-date-extraction` on a filename with an ISO8601 date, the entry has been written twice.