### PR TITLE
replace python shebang to choose environments python executable

### DIFF
--- a/bin/memacs_battery.py
+++ b/bin/memacs_battery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from memacs.battery import Battery

--- a/bin/memacs_lastfm.py
+++ b/bin/memacs_lastfm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from memacs.lastfm import LastFM

--- a/bin/memacs_whatsapp.py
+++ b/bin/memacs_whatsapp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from memacs.whatsapp import WhatsApp

--- a/docs/memacs_twitter.org
+++ b/docs/memacs_twitter.org
@@ -25,7 +25,7 @@ and write to your Twitter account.
 
 You need to obtain an Authorization Url. Create and run the following program:
 
-#+begin_src python :shebang #!/usr/bin/python2 :tangle ./twitter_get_auth.py :exports none :noweb yes
+#+begin_src python :shebang #!/usr/bin/env python2 :tangle ./twitter_get_auth.py :exports none :noweb yes
 from twython import Twython
 APP_KEY = 'Your Consumer Key'
 APP_SECRET = 'Your Consumer Secret'
@@ -54,7 +54,7 @@ obtain your Final Tokens.
 Finally enter the data you got from running the program twitter_get_auth.py into the
 program below to get your final tokens.
 
-#+begin_src python :shebang #!/usr/bin/python2 :tangle ./twitter_get_final_tokens.py :exports none :noweb yes
+#+begin_src python :shebang #!/usr/bin/env python2 :tangle ./twitter_get_final_tokens.py :exports none :noweb yes
 from twython import Twython
 APP_KEY = 'Your Consumer Key'
 APP_SECRET = 'Your Consumer Secret'

--- a/memacs/battery.py
+++ b/memacs/battery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import time


### PR DESCRIPTION
As already done in some modules I see no reason why in some modules the python executable should be hardcoded instead of letting the environment decide which python executable to choose