### PR TITLE
fix timestamp gathering for csv.

### DIFF
--- a/memacs/csv.py
+++ b/memacs/csv.py
@@ -93,8 +93,8 @@ class Csv(Memacs):
 
             # show time with the timestamp format, but only
             # if it contains at least hours and minutes
-            if not self._args.timestamp_format and \
-            (x in self._args.timestamp_format for x in ['%H', '%M']):
+            if not self._args.timestamp_format or \
+             (x in self._args.timestamp_format for x in ['%H', '%M']):
                 timestamp = OrgFormat.datetime(timestamp)
             else:
                 timestamp = OrgFormat.date(timestamp)


### PR DESCRIPTION
Use hour and minute when there's no particular timestamp_format or
when there is timestamp_format and it provides them.  Default
timestamp_format is able to give hour and minute from a timestamp.