### PR TITLE
Make subject an optional property of sms to make it compatible with Signal

### DIFF
--- a/memacs/sms.py
+++ b/memacs/sms.py
@@ -118,7 +118,7 @@ class SmsSaxHandler(xml.sax.handler.ContentHandler):
         htmlparser = html.parser.HTMLParser()
 
         if name == "sms":
-            sms_subject = attrs['subject']
+            sms_subject = attrs.get('subject','')
             sms_date = int(attrs['date']) / 1000     # unix epoch
             sms_body = attrs['body']
             sms_address = attrs['address'].strip().replace('-','').replace('/','').replace(' ','').replace('+','00')


### PR DESCRIPTION
I use [signal-back](https://github.com/xeals/signal-back) to convert signal-backup files to xml files compatible with SMS Backup & Restore. Unfortunately the `subject` property is missing. Therefore I would like to make the subject property optional, replacing it with the empty string if it's not available.