### PR TITLE
Use Org-Contacts in whatsapp module

### DIFF
--- a/memacs/lib/contactparser.py
+++ b/memacs/lib/contactparser.py
@@ -1,0 +1,68 @@
+import re
+import logging
+
+def parse_org_contact_file(orgfile):
+    """
+    Parses the given Org-mode file for contact entries.
+
+    The return format is a follows:
+    numbers = {'004369912345678':'First2 Last1', '0316987654':'First2 Last2', ...}
+
+    @param orgfile: file name of a Org-mode file to parse
+    @param return: list of dict-entries containing the numbers to name dict
+    """
+
+    linenr = 0
+
+    ## defining distinct parsing status states:
+    headersearch = 21
+    propertysearch = 42
+    inproperty = 73
+    status = headersearch
+
+    contacts = {}
+    current_name = ''
+
+    HEADER_REGEX = re.compile('^(\*+)\s+(.*?)(\s+(:\S+:)+)?$')
+    PHONE = '\s+([\+\d\-/ ]{7,})$'
+    PHONE_REGEX = re.compile(':(PHONE|oldPHONE|MOBILE|oldMOBILE|HOMEPHONE|oldHOMEPHONE|WORKPHONE|oldWORKPHONE):' + PHONE)
+
+    for rawline in open(orgfile, 'r'):
+        line = rawline.strip()   ## trailing and leading spaces are stupid
+        linenr += 1
+
+        header_components = re.match(HEADER_REGEX, line)
+        if header_components:
+            ## in case of new header, make new currententry because previous one was not a contact header with a property
+            current_name = header_components.group(2)
+            status = propertysearch
+            continue
+
+        if status == headersearch:
+            ## if there is something to do, it was done above when a new heading is found
+            continue
+
+        if status == propertysearch:
+            if line == ':PROPERTIES:':
+                status = inproperty
+            continue
+
+        elif status == inproperty:
+
+            phone_components = re.match(PHONE_REGEX, line)
+            if phone_components:
+                phonenumber = phone_components.group(2).strip().replace('-','').replace('/','').replace(' ','').replace('+','00')
+                contacts[phonenumber] = current_name
+            elif line == ':END:':
+                status = headersearch
+
+            continue
+
+        else:
+            ## I must have mixed up status numbers or similar - should never be reached.
+            logging.error("Oops. Internal parser error: status \"%s\" unknown. The programmer is an idiot. Current contact entry might get lost due to recovering from that shock. (line number %s)" % (str(status), str(linenr)))
+            status = headersearch
+            continue
+
+    logging.info("found %s suitable contacts while parsing \"%s\"" % (str(len(contacts)), orgfile))
+    return contacts

--- a/memacs/sms.py
+++ b/memacs/sms.py
@@ -16,6 +16,7 @@ from .lib.orgformat import OrgFormat
 from .lib.orgproperty import OrgProperties
 from .lib.memacs import Memacs
 from .lib.reader import CommonReader
+from .lib.contactparser import parse_org_contact_file
 
 
 class SmsSaxHandler(xml.sax.handler.ContentHandler):
@@ -214,72 +215,6 @@ class SmsMemacs(Memacs):
             help="path to Org-contacts file for phone number lookup. Phone numbers have to match.")
 
 
-    def parse_org_contact_file(self, orgfile):
-        """
-        Parses the given Org-mode file for contact entries.
-
-        The return format is a follows:
-        numbers = {'004369912345678':'First2 Last1', '0316987654':'First2 Last2', ...}
-
-        @param orgfile: file name of a Org-mode file to parse
-        @param return: list of dict-entries containing the numbers to name dict
-        """
-
-        linenr = 0
-
-        ## defining distinct parsing status states:
-        headersearch = 21
-        propertysearch = 42
-        inproperty = 73
-        status = headersearch
-
-        contacts = {}
-        current_name = ''
-
-        HEADER_REGEX = re.compile('^(\*+)\s+(.*?)(\s+(:\S+:)+)?$')
-        PHONE = '\s+([\+\d\-/ ]{7,})$'
-        PHONE_REGEX = re.compile(':(PHONE|oldPHONE|MOBILE|oldMOBILE|HOMEPHONE|oldHOMEPHONE|WORKPHONE|oldWORKPHONE):' + PHONE)
-
-        for rawline in codecs.open(orgfile, 'r', encoding='utf-8'):
-            line = rawline.strip()   ## trailing and leading spaces are stupid
-            linenr += 1
-
-            header_components = re.match(HEADER_REGEX, line)
-            if header_components:
-                ## in case of new header, make new currententry because previous one was not a contact header with a property
-                current_name = header_components.group(2)
-                status = propertysearch
-                continue
-
-            if status == headersearch:
-                ## if there is something to do, it was done above when a new heading is found
-                continue
-
-            if status == propertysearch:
-                if line == ':PROPERTIES:':
-                    status = inproperty
-                continue
-
-            elif status == inproperty:
-
-                phone_components = re.match(PHONE_REGEX, line)
-                if phone_components:
-                    phonenumber = phone_components.group(2).strip().replace('-','').replace('/','').replace(' ','').replace('+','00')
-                    contacts[phonenumber] = current_name
-                elif line == ':END:':
-                    status = headersearch
-
-                continue
-
-            else:
-                ## I must have mixed up status numbers or similar - should never be reached.
-                logging.error("Oops. Internal parser error: status \"%s\" unknown. The programmer is an idiot. Current contact entry might get lost due to recovering from that shock. (line number %s)" % (str(status), str(linenr)))
-                status = headersearch
-                continue
-
-        logging.info("found %s suitable contacts while parsing \"%s\"" % (str(len(contacts)), orgfile))
-        return contacts
-
 
     def _parser_parse_args(self):
         """
@@ -296,7 +231,7 @@ class SmsMemacs(Memacs):
             if not (os.path.exists(self._args.orgcontactsfile) or \
                     os.access(self._args.orgcontactsfile, os.R_OK)):
                 self._parser.error("Org-contacts file not found or not readable")
-            self._numberdict = self.parse_org_contact_file(self._args.orgcontactsfile)
+            self._numberdict = parse_org_contact_file(self._args.orgcontactsfile)
 
 
     def _main(self):

--- a/memacs/whatsapp.py
+++ b/memacs/whatsapp.py
@@ -16,9 +16,11 @@ import emoji
 from .lib.orgproperty import OrgProperties
 from .lib.orgformat import OrgFormat
 from .lib.memacs import Memacs
-
+from .lib.contactparser import parse_org_contact_file
 
 class WhatsApp(Memacs):
+
+
     def _parser_add_arguments(self):
         """
         overwritten method of class Memacs
@@ -42,7 +44,7 @@ class WhatsApp(Memacs):
 
         self._parser.add_argument(
             "--output-format", dest="output_format",
-            action="store", default="{verb} [[{handler}:{number}][{number}]]: {text}",
+            action="store", default="{verb} [[{handler}:{name}][{name}]]: {text}",
             help="format string to use for the headline")
 
         self._parser.add_argument(
@@ -58,6 +60,13 @@ class WhatsApp(Memacs):
             "--skip-emoji", dest="skip_emoji",
             action="store_true", help="skip all emoji")
 
+        self._parser.add_argument(
+            "--orgcontactsfile", dest="orgcontactsfile",
+            action="store", required=False,
+            help="path to Org-contacts file for phone number lookup. Phone numbers have to match.")
+
+
+
     def _parser_parse_args(self):
         """
         overwritten method of class Memacs
@@ -65,6 +74,13 @@ class WhatsApp(Memacs):
         all additional arguments are parsed in here
         """
         Memacs._parser_parse_args(self)
+        if self._args.orgcontactsfile:
+            if not (os.path.exists(self._args.orgcontactsfile) or \
+                    os.access(self._args.orgcontactsfile, os.R_OK)):
+                self._parser.error("Org-contacts file not found or not readable")
+            self._numberdict = parse_org_contact_file(self._args.orgcontactsfile)
+        else:
+            self._numberdict = {}
 
     def _is_ignored(self, msg):
         """check for ignored message type"""
@@ -79,6 +95,7 @@ class WhatsApp(Memacs):
         """parse a single message row"""
 
         msg['number'] = '00' + msg['number'].split('@')[0]
+        msg['name'] = self._numberdict.get(msg['number'],msg['number'])
         msg['verb'] = 'to' if msg['type'] else 'from'
         msg['type'] = 'OUTGOING' if msg['type'] else 'INCOMING'
         msg['handler'] = self._args.handler


### PR DESCRIPTION
I wanted to use the org-contacts feature also in the whatsapp module, therefore I factored out the `parse_org_contacts_file` function into its own file and then used it also in the whatsapp module, if the number is not in the file, the phone-number is used as before.