### PR TITLE
Fix errors in LastFM module due to change to python3

### DIFF
--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -37,7 +37,7 @@ class LastFM(Memacs):
         Memacs._parser_parse_args(self)
 
         if self._args.output_format:
-            self._args.output_format = self._args.output_format.decode('utf-8')
+            self._args.output_format = self._args.output_format
 
     def _handle_recent_tracks(self, tracks):
         """parse recent tracks"""

--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -73,10 +73,10 @@ class LastFM(Memacs):
         try:
 
             if 'lastfm' in self._get_config_option('network'):
-                network = pylast.get_lastfm_network(**options)
+                network = pylast.LastFMNetwork(**options)
 
             if 'librefm' in self._get_config_option('network'):
-                network = pylast.get_librefm_network(**options)
+                network = pylast.LibreFMNetwork(**options)
 
             user = network.get_user(options['username'])
 

--- a/memacs/lib/memacs.py
+++ b/memacs/lib/memacs.py
@@ -140,7 +140,7 @@ class Memacs(object):
         if self.__config_parser:
             ret = self.__config_parser.get(self.__use_config_parser_name,
                                            option)
-            return ret.decode("utf-8")
+            return ret
         else:
             raise Exception("no config parser specified, cannot get option")
 


### PR DESCRIPTION
fixes #68 

- removed decode/encode call
- updated pylast call to newer version

Things to think about:
- There are no tests for this module since it requires an api call. Not sure if it's worth it mocking the api to test the module but this error only wasn't catched by the unittests because there weren't any tests for it.
- Many modules depend on other python modules (often specific versions), do we want to put all of them in the requirements.txt allthough not everybody is using every module?