### PR TITLE
fix phonecalls_superbackup error due to minimum_duration equal None

### DIFF
--- a/memacs/phonecalls_superbackup.py
+++ b/memacs/phonecalls_superbackup.py
@@ -233,7 +233,7 @@ class PhonecallsSuperBackupMemacs(Memacs):
                                               self._args.ignore_voicemail,
                                               self._args.ignore_rejected,
                                               self._args.ignore_refused,
-                                              self._args.minimum_duration,
+                                              self._args.minimum_duration or 0,
                                               ))
         except SAXParseException:
             logging.error("No correct XML given")


### PR DESCRIPTION
fixes #67 

In Python3 one cannot compare with None, therefore the minimum duration must be set to zero if it is None.


Again, there is no test for this module so it would be nice to have somebody who is using superbackup to provide some sample data to create a test for it