### PR TITLE
Add Kodi module to import logs from Kodi Mediacenter

### DIFF
--- a/bin/memacs_kodi.py
+++ b/bin/memacs_kodi.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from memacs.kodi import Kodi
+
+PROG_VERSION_NUMBER = "0.1"
+PROG_VERSION_DATE = "2018-10-22"
+PROG_SHORT_DESCRIPTION = "Memacs for Kodi "
+PROG_TAG = "kodi"
+PROG_DESCRIPTION = """
+this class will parse logs from the Kodi Mediacenter
+
+"""
+COPYRIGHT_YEAR = "2018"
+COPYRIGHT_AUTHORS = """Max Beutelspacher <max.beutelspacher@mailbox.org>"""
+
+
+if __name__ == "__main__":
+    memacs = Kodi(
+        prog_version=PROG_VERSION_NUMBER,
+        prog_version_date=PROG_VERSION_DATE,
+        prog_description=PROG_DESCRIPTION,
+        prog_short_description=PROG_SHORT_DESCRIPTION,
+        prog_tag=PROG_TAG,
+        copyright_year=COPYRIGHT_YEAR,
+        copyright_authors=COPYRIGHT_AUTHORS
+#       use_config_parser_name=CONFIG_PARSER_NAME
+        )
+    memacs.handle_main()

--- a/docs/memacs_kodi.org
+++ b/docs/memacs_kodi.org
@@ -37,7 +37,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
 #+BEGIN_SRC org
 * Memacs for Kodi           :Memacs:kodi:
 ** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso-So sehr dabei
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      So sehr dabei
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -45,7 +45,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
   :END:
 
 ** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso-Chicago
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      Chicago
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -53,7 +53,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
   :END:
 
 ** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:15> Clueso-So sehr dabei
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      So sehr dabei
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -61,7 +61,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
   :END:
 
 ** <2018-10-01 Mon 22:16>--<2018-10-01 Mon 22:26> Clueso-So sehr dabei
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      So sehr dabei
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -83,7 +83,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
 #+BEGIN_SRC org
 * Memacs for Kodi           :Memacs:kodi:
 ** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso-So sehr dabei
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      So sehr dabei
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -91,7 +91,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
   :END:
 
 ** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso-Chicago
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      Chicago
   :ALBUM:      Barfuss
   :ARTIST:     Clueso
@@ -99,7 +99,7 @@ bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
   :END:
 
 ** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:26> Clueso-So sehr dabei
-   :PROPERTIES:
+  :PROPERTIES:
   :TITLE:      So sehr dabei
   :ALBUM:      Barfuss
   :ARTIST:     Clueso

--- a/docs/memacs_kodi.org
+++ b/docs/memacs_kodi.org
@@ -1,0 +1,110 @@
+## This file is best viewed with GNU Emacs Org-mode: http://orgmode.org/
+
+* memacs_csv
+
+** Data Source
+Log-Files of Media played by [[https://kodi.tv/][Kodi Mediacenter]] exported e.g. by the Kodi Addon [[https://github.com/DerBeutlin/KodiPlayEventLogger][KodiPlayEventLogger]].
+The Files are csv files which log each start/pause/stop of media played
+
+** Options
+
+Since this module subclasses the Memacs CSV module many of the parameters are the same:
+- ~-f, --file~ input csv file (required)
+- ~-d, --delimiter~ defaults to semicolon
+- ~-e, --encoding~ see [[http://docs.python.org/library/codecs.html#standard-encodings][encodings]], defaults to ~utf-8~
+- ~-n, --fieldnames~ header fieldnames of the columns (add a comma at the end, if data rows end with delimiter)
+- ~-p, --properties~ fields to use for properties (optional)
+- ~--timestamp-field~ field name of the timestamp (required)
+- ~--timestamp-format~ format of the timestamp, see [[http://docs.python.org/library/time.html#time.strftime][strftime]] for possible formats, defaults to unix timestamp
+- ~--output-format~ format string for the output, see [[https://pyformat.info/][format]] and use the fieldnames as named placeholders (required)
+- ~--skip-header~ skip first line, only necessary if you want to overwrite existing header fieldnames (optional)
+
+The following parameters are added through the Kodi module
+- ~--action-field~ field name of the action label (started/stopped/paused) (required)
+- ~--identification-fields~ fields to uniquely identify track e.g. 'title,artist' (required)
+- ~--minimal-pause-duration~ pauses in the same media which are shorter than this threshold are ignored (optional)
+
+** Example
+
+#+BEGIN_EXAMPLE
+bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
+                   --fieldnames timestamp,action,position,length,path,album,artist,title,\
+                   --timestamp-field timestamp --properties title,album,artist \
+                   --output-format {artist}-{title} --action-field action \
+                   --identification-fields title,album,artist, \
+#+END_EXAMPLE
+
+#+BEGIN_SRC org
+* Memacs for Kodi           :Memacs:kodi:
+** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso-So sehr dabei
+   :PROPERTIES:
+  :TITLE:      So sehr dabei
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         1831baa1c211e878d0ce1e643b7185059b16caf5
+  :END:
+
+** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso-Chicago
+   :PROPERTIES:
+  :TITLE:      Chicago
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         a792da84d9840f013e098cf4c99e3d6312d1975d
+  :END:
+
+** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:15> Clueso-So sehr dabei
+   :PROPERTIES:
+  :TITLE:      So sehr dabei
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         f544004d78f6b03226f50b439449605218d8167d
+  :END:
+
+** <2018-10-01 Mon 22:16>--<2018-10-01 Mon 22:26> Clueso-So sehr dabei
+   :PROPERTIES:
+  :TITLE:      So sehr dabei
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         d344cca12917de1166b517657f4a7d176767ce53
+  :END:
+
+* successfully parsed 4 entries by ./bin/memacs_kodi.py at [2018-10-27 Sat 16:07] in ~0.001384s .
+#+END_SRC
+ -----
+
+#+BEGIN_EXAMPLE
+bin/memacs_kodi.py -f memacs/tests/data/kodi_audio.log \
+                   --fieldnames timestamp,action,position,length,path,album,artist,title,\
+                   --timestamp-field timestamp --properties title,album,artist \
+                   --output-format {artist}-{title} --action-field action \
+                   --identification-fields title,album,artist, \
+                   --minimal-pause-duration 120
+#+END_EXAMPLE
+#+BEGIN_SRC org
+* Memacs for Kodi           :Memacs:kodi:
+** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso-So sehr dabei
+   :PROPERTIES:
+  :TITLE:      So sehr dabei
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         1831baa1c211e878d0ce1e643b7185059b16caf5
+  :END:
+
+** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso-Chicago
+   :PROPERTIES:
+  :TITLE:      Chicago
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         a792da84d9840f013e098cf4c99e3d6312d1975d
+  :END:
+
+** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:26> Clueso-So sehr dabei
+   :PROPERTIES:
+  :TITLE:      So sehr dabei
+  :ALBUM:      Barfuss
+  :ARTIST:     Clueso
+  :ID:         d344cca12917de1166b517657f4a7d176767ce53
+  :END:
+
+* successfully parsed 3 entries by ./bin/memacs_kodi.py at [2018-10-27 Sat 16:10] in ~0.001130s .
+#+END_SRC

--- a/memacs/kodi.py
+++ b/memacs/kodi.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+import argparse
+import json
+import logging
+import time
+import csv
+import datetime
+from .lib.orgproperty import OrgProperties
+from .lib.orgformat import OrgFormat
+from .lib.memacs import Memacs
+from .lib.reader import UnicodeDictReader
+from .csv import Csv
+
+from itertools import tee, islice, chain
+
+
+# stolen from https://stackoverflow.com/questions/1011938/python-previous-and-next-values-inside-a-loop/1012089#1012089
+def previous_and_current(some_iterable):
+    prevs, items = tee(some_iterable, 2)
+    prevs = chain([None], prevs)
+    return zip(prevs, items)
+
+
+class Kodi(Csv):
+    def _parser_add_arguments(self):
+        """
+        overwritten method of class Memacs
+
+        add additional arguments
+        """
+        super()._parser_add_arguments()
+
+        self._parser.add_argument(
+            '--action-field',
+            dest="action_field",
+            required=True,
+            action='store',
+            help='field name of the action (start/paused,stopped)',
+            type=str.lower)
+
+
+    def read_timestamp(self, row):
+        if not self._args.timestamp_format:
+            timestamp = datetime.datetime.fromtimestamp(
+                int(row[self._args.timestamp_field]))
+        else:
+            timestamp = time.strptime(row[self._args.timestamp_field],
+                                      self._args.timestamp_format)
+
+        # show time with the timestamp format, but only
+        # if it contains at least hours and minutes
+        if not self._args.timestamp_format or \
+            any(x in self._args.timestamp_format for x in ['%H', '%M']):
+            timestamp = OrgFormat.datetime(timestamp)
+        else:
+            timestamp = OrgFormat.date(timestamp)
+        return timestamp
+
+    def read_properties(self, row):
+        properties = OrgProperties(data_for_hashing=json.dumps(row))
+        output = self._args.output_format.format(**row)
+
+        if self._args.properties:
+            for prop in self._args.properties.split(','):
+                properties.add(prop.upper().strip(), row[prop])
+        return properties
+
+    def write_one_track(self, row, start_time, stop_time):
+        properties = self.read_properties(row)
+        output = self._args.output_format.format(**row)
+        self._writer.write_org_subitem(
+            timestamp=start_time + '--' + stop_time,
+            output=output,
+            properties=properties)
+
+    def read_log(self, reader):
+        """goes through rows and searches for start/stop actions"""
+        start_actions = ['started', 'resumed']
+        stop_actions = ['paused', 'stopped']
+        start_time, stop_time = None, None
+        for prev_row, row in previous_and_current(reader):
+            timestamp = self.read_timestamp(row)
+            action = row[self._args.action_field]
+            if action in start_actions:
+                if not start_time:
+                    start_time = timestamp
+                else:
+                    if prev_row:
+                        self.write_one_track(prev_row, start_time, timestamp)
+                    start_time = timestamp
+            elif action in stop_actions and start_time:
+                stop_time = timestamp
+            if start_time and stop_time:
+                self.write_one_track(row, start_time, stop_time)
+                start_time, stop_time = None, None
+
+    def _main(self):
+        """
+        get's automatically called from Memacs class
+        """
+
+        with self._args.csvfile as f:
+
+            try:
+                reader = UnicodeDictReader(f, self._args.delimiter,
+                                           self._args.encoding,
+                                           self._args.fieldnames)
+
+                if self._args.skip_header:
+                    next(reader)
+
+                self.read_log(reader)
+
+            except TypeError as e:
+                logging.error("not enough fieldnames or wrong delimiter given")
+                logging.debug("Error: %s" % e)
+                sys.exit(1)
+
+            except UnicodeDecodeError as e:
+                logging.error(
+                    "could not decode file in utf-8, please specify input encoding"
+                )
+                sys.exit(1)

--- a/memacs/kodi.py
+++ b/memacs/kodi.py
@@ -17,10 +17,11 @@ from itertools import tee, islice, chain
 
 
 # stolen from https://stackoverflow.com/questions/1011938/python-previous-and-next-values-inside-a-loop/1012089#1012089
-def previous_and_current(some_iterable):
-    prevs, items = tee(some_iterable, 2)
+def previous_current_next(some_iterable):
+    prevs, items, nexts = tee(some_iterable, 3)
     prevs = chain([None], prevs)
-    return zip(prevs, items)
+    nexts = chain(islice(nexts, 1, None), [None])
+    return zip(prevs, items, nexts)
 
 
 class Kodi(Csv):
@@ -40,6 +41,38 @@ class Kodi(Csv):
             help='field name of the action (start/paused,stopped)',
             type=str.lower)
 
+        self._parser.add_argument(
+            '--identification-fields',
+            dest="identification_fields",
+            required=True,
+            action='store',
+            help='field names to uniquely identify one track e.g. title,artist',
+            type=str.lower)
+
+        self._parser.add_argument(
+            '--minimal-pause-duration',
+            dest='minimal_pause_duration',
+            required=False,
+            action='store',
+            default=0,
+            help=
+            'minimal duration in seconds of a pause to be logged as a pause instead of being ignored',
+            type=int,
+        )
+
+    def _parser_parse_args(self):
+        """
+        overwritten method of class Memacs
+
+        all additional arguments are parsed in here
+        """
+        super()._parser_parse_args()
+
+        if self._args.identification_fields:
+            self._args.identification_fields = [
+                name.strip()
+                for name in self._args.identification_fields.split(',')
+            ]
 
     def read_timestamp(self, row):
         if not self._args.timestamp_format:
@@ -49,6 +82,9 @@ class Kodi(Csv):
             timestamp = time.strptime(row[self._args.timestamp_field],
                                       self._args.timestamp_format)
 
+        return timestamp
+
+    def format_timestamp(self, timestamp):
         # show time with the timestamp format, but only
         # if it contains at least hours and minutes
         if not self._args.timestamp_format or \
@@ -71,29 +107,44 @@ class Kodi(Csv):
         properties = self.read_properties(row)
         output = self._args.output_format.format(**row)
         self._writer.write_org_subitem(
-            timestamp=start_time + '--' + stop_time,
+            timestamp=self.format_timestamp(start_time) + '--' +
+            self.format_timestamp(stop_time),
             output=output,
             properties=properties)
+
+    def tracks_are_identical(self, row1, row2):
+        for field in self._args.identification_fields:
+            if row1[field] != row2[field]:
+                return False
+        return True
+
+    def track_is_paused(self, row, next_row):
+        return next_row and self.tracks_are_identical(row, next_row) and (
+            self.read_timestamp(next_row) - self.read_timestamp(row)
+        ).total_seconds() < self._args.minimal_pause_duration
 
     def read_log(self, reader):
         """goes through rows and searches for start/stop actions"""
         start_actions = ['started', 'resumed']
         stop_actions = ['paused', 'stopped']
         start_time, stop_time = None, None
-        for prev_row, row in previous_and_current(reader):
+        for prev_row, row, next_row in previous_current_next(reader):
             timestamp = self.read_timestamp(row)
             action = row[self._args.action_field]
             if action in start_actions:
                 if not start_time:
                     start_time = timestamp
-                else:
-                    if prev_row:
-                        self.write_one_track(prev_row, start_time, timestamp)
+                elif prev_row and not self.track_is_paused(prev_row, row):
+                    self.write_one_track(prev_row, start_time, timestamp)
                     start_time = timestamp
             elif action in stop_actions and start_time:
-                stop_time = timestamp
+                if not self.track_is_paused(row, next_row):
+                    stop_time = timestamp
+                else:
+                    stop_time = None
             if start_time and stop_time:
-                self.write_one_track(row, start_time, stop_time)
+                if self.tracks_are_identical(row, prev_row):
+                    self.write_one_track(row, start_time, stop_time)
                 start_time, stop_time = None, None
 
     def _main(self):

--- a/memacs/tests/data/kodi_audio.log
+++ b/memacs/tests/data/kodi_audio.log
@@ -1,0 +1,5 @@
+1538423930;started;0;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
+1538423952;stopped;20;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
+1538424200;started;21;159;musicdb://songs/26.ogg;Barfuss;Clueso;Chicago;
+1538424500;started;0;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
+1538424902;paused;20;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;

--- a/memacs/tests/data/kodi_audio.log
+++ b/memacs/tests/data/kodi_audio.log
@@ -3,3 +3,5 @@
 1538424200;started;21;159;musicdb://songs/26.ogg;Barfuss;Clueso;Chicago;
 1538424500;started;0;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
 1538424902;paused;20;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
+1538424982;started;20;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;
+1538425600;paused;20;158;musicdb://songs/26.ogg;Barfuss;Clueso;So sehr dabei;

--- a/memacs/tests/kodi_test.py
+++ b/memacs/tests/kodi_test.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from memacs.kodi import Kodi
+import os
+
+
+class TestKodi(unittest.TestCase):
+    def test_audio_log(self):
+
+        log_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'data',
+            'kodi_audio.log')
+        argv = []
+        argv.append("-f")
+        argv.append(log_file)
+        argv.append("--fieldnames")
+        argv.append(
+            'timestamp,action,position,length,path,album,artist,title,')
+        argv.append("--timestamp-field")
+        argv.append("timestamp")
+        argv.append("--action-field")
+        argv.append("action")
+        argv.append("--output-format")
+        argv.append("{artist} - {title}")
+        argv.append("--properties")
+        argv.append("album,artist,title")
+
+        memacs = Kodi(argv=argv)
+        data = memacs.test_get_entries()
+
+        # Test Simple Play and Paused
+        self.assertEqual(
+            data[0],
+            "** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso - So sehr dabei"
+        )
+        self.assertEqual(data[1], "   :PROPERTIES:")
+        self.assertEqual(data[2], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[3], "   :ARTIST:     Clueso")
+        self.assertEqual(data[4], "   :TITLE:      So sehr dabei")
+        self.assertEqual(
+            data[5],
+            "   :ID:         332b5cd71e335d2cf55f681a3a1fc26161465069")
+        self.assertEqual(data[6], "   :END:")
+
+        #Test started one track and switched to another
+        self.assertEqual(
+            data[7],
+            "** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso - Chicago"
+        )
+        self.assertEqual(data[8], "   :PROPERTIES:")
+        self.assertEqual(data[9], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[10], "   :ARTIST:     Clueso")
+        self.assertEqual(data[11], "   :TITLE:      Chicago")
+        self.assertEqual(
+            data[12],
+            "   :ID:         13b38e428bb4d8c9e55183877096c921bee871e5")
+        self.assertEqual(data[13], "   :END:")
+        self.assertEqual(
+            data[14],
+            "** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:15> Clueso - So sehr dabei"
+        )
+        self.assertEqual(data[15], "   :PROPERTIES:")
+        self.assertEqual(data[16], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[17], "   :ARTIST:     Clueso")
+        self.assertEqual(data[18], "   :TITLE:      So sehr dabei")
+        self.assertEqual(
+            data[19],
+            "   :ID:         4ed907d4337faaca7b2fd059072fc5046e80dc11")
+        self.assertEqual(data[20], "   :END:")

--- a/memacs/tests/kodi_test.py
+++ b/memacs/tests/kodi_test.py
@@ -6,8 +6,7 @@ import os
 
 
 class TestKodi(unittest.TestCase):
-    def test_audio_log(self):
-
+    def setUp(self):
         log_file = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), 'data',
             'kodi_audio.log')
@@ -21,12 +20,17 @@ class TestKodi(unittest.TestCase):
         argv.append("timestamp")
         argv.append("--action-field")
         argv.append("action")
+        argv.append("--identification-fields")
+        argv.append("artist,title")
         argv.append("--output-format")
         argv.append("{artist} - {title}")
         argv.append("--properties")
         argv.append("album,artist,title")
+        self.argv = argv
 
-        memacs = Kodi(argv=argv)
+    def test_audio_log(self):
+
+        memacs = Kodi(argv=self.argv)
         data = memacs.test_get_entries()
 
         # Test Simple Play and Paused
@@ -67,4 +71,61 @@ class TestKodi(unittest.TestCase):
         self.assertEqual(
             data[19],
             "   :ID:         4ed907d4337faaca7b2fd059072fc5046e80dc11")
+        self.assertEqual(data[20], "   :END:")
+        # Pause is logged
+        self.assertEqual(
+            data[21],
+            "** <2018-10-01 Mon 22:16>--<2018-10-01 Mon 22:26> Clueso - So sehr dabei"
+        )
+        self.assertEqual(data[22], "   :PROPERTIES:")
+        self.assertEqual(data[23], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[24], "   :ARTIST:     Clueso")
+        self.assertEqual(data[25], "   :TITLE:      So sehr dabei")
+        self.assertEqual(
+            data[26],
+            "   :ID:         9e504573886f483fa8f84fb5a8bc5d9e05be7bab")
+        self.assertEqual(data[27], "   :END:")
+
+    def test_audio_log_with_minimal_duration(self):
+        self.argv.append('--minimal-pause-duration')
+        self.argv.append('120')
+        memacs = Kodi(argv=self.argv)
+        data = memacs.test_get_entries()
+        # pause is ignored
+        self.assertEqual(
+            data[0],
+            "** <2018-10-01 Mon 21:58>--<2018-10-01 Mon 21:59> Clueso - So sehr dabei"
+        )
+        self.assertEqual(data[1], "   :PROPERTIES:")
+        self.assertEqual(data[2], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[3], "   :ARTIST:     Clueso")
+        self.assertEqual(data[4], "   :TITLE:      So sehr dabei")
+        self.assertEqual(
+            data[5],
+            "   :ID:         332b5cd71e335d2cf55f681a3a1fc26161465069")
+        self.assertEqual(data[6], "   :END:")
+
+        self.assertEqual(
+            data[7],
+            "** <2018-10-01 Mon 22:03>--<2018-10-01 Mon 22:08> Clueso - Chicago"
+        )
+        self.assertEqual(data[8], "   :PROPERTIES:")
+        self.assertEqual(data[9], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[10], "   :ARTIST:     Clueso")
+        self.assertEqual(data[11], "   :TITLE:      Chicago")
+        self.assertEqual(
+            data[12],
+            "   :ID:         13b38e428bb4d8c9e55183877096c921bee871e5")
+        self.assertEqual(data[13], "   :END:")
+        self.assertEqual(
+            data[14],
+            "** <2018-10-01 Mon 22:08>--<2018-10-01 Mon 22:26> Clueso - So sehr dabei"
+        )
+        self.assertEqual(data[15], "   :PROPERTIES:")
+        self.assertEqual(data[16], "   :ALBUM:      Barfuss")
+        self.assertEqual(data[17], "   :ARTIST:     Clueso")
+        self.assertEqual(data[18], "   :TITLE:      So sehr dabei")
+        self.assertEqual(
+            data[19],
+            "   :ID:         9e504573886f483fa8f84fb5a8bc5d9e05be7bab")
         self.assertEqual(data[20], "   :END:")


### PR DESCRIPTION
This adds a module that is based on the memacs csv module and allows for importing log files from Kodi e.g. exported through [KodiPlayEventLogger](https://github.com/DerBeutlin/KodiPlayEventLogger) to solve #57.

 A threshold for pauses can be defined.

Right now there is no option to create a link to the file since Kodi might be running on a different machine than Memacs.