### PR TITLE
Fix problems when locale is not en_US

### DIFF
--- a/memacs/mu.py
+++ b/memacs/mu.py
@@ -2,11 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import subprocess
+import locale
 from datetime import datetime
 from .lib.orgproperty import OrgProperties
 from .lib.orgformat import OrgFormat
 from .lib.memacs import Memacs
 import re
+
+# Sets this script's locale to be the same as system locale
+locale.setlocale(locale.LC_TIME, '')
 
 class MuMail(Memacs):
         
@@ -66,7 +70,7 @@ class MuMail(Memacs):
         converts xml timestamp into org readable timestamp
         Do  6 Nov 21:22:17 2014
         """
-        time = time.strip().encode('utf-8')
+        time = time.strip()
 
         mail_date = datetime.strptime(time,"%c")
         if onlyDate is False:


### PR DESCRIPTION
When the locale is not en_US, the time string will be in another language, and Python's %c can't parse it unless it knows what locale it is. This problem was making memacs_mumail not run for me, because my system is set up to use Brazilian Portuguese.

My changes pick up the system locale. Also I removed an encode() call that was not needed and was causing problems. Now it works with my pt_BR locale!

This should even fix issue #43. Maybe.