### PR TITLE
replace relative imports with absolute imports and port chrome script to python3

### DIFF
--- a/memacs/arbtt.py
+++ b/memacs/arbtt.py
@@ -11,9 +11,9 @@ import time
 import sys
 import io
 
-from .lib.reader import UnicodeCsvReader
-from .lib.orgproperty import OrgProperties
-from .lib.memacs import Memacs
+from memacs.lib.reader import UnicodeCsvReader
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.memacs import Memacs
 
 ARBTT_STATS = 'arbtt-stats'
 ARBTT_FORMAT = '%m/%d/%y %H:%M:%S'

--- a/memacs/battery.py
+++ b/memacs/battery.py
@@ -8,9 +8,9 @@ import sys
 
 import batinfo
 
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 ROOT = '/sys/class/power_supply'
 

--- a/memacs/chrome.py
+++ b/memacs/chrome.py
@@ -12,8 +12,6 @@ from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.orgformat import OrgFormat
 from memacs.lib.memacs import Memacs
 
-# reload(sys)
-# sys.setdefaultencoding('utf8')
 
 class Chrome(Memacs):
     def _parser_add_arguments(self):
@@ -26,7 +24,7 @@ class Chrome(Memacs):
 
         self._parser.add_argument(
             "-f", "--file", dest="historystore",
-            action="store", type=file, required=True,
+            action="store", type=open, required=True,
             help="""path to Google Chrome History sqlite file. usually in
 /home/bala/.config/google-chrome/Default/History """)
 

--- a/memacs/chrome.py
+++ b/memacs/chrome.py
@@ -8,12 +8,12 @@ import sys
 import os
 import re
 
-from lib.orgproperty import OrgProperties
-from lib.orgformat import OrgFormat
-from lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
-reload(sys)
-sys.setdefaultencoding('utf8')
+# reload(sys)
+# sys.setdefaultencoding('utf8')
 
 class Chrome(Memacs):
     def _parser_add_arguments(self):

--- a/memacs/csv.py
+++ b/memacs/csv.py
@@ -9,10 +9,10 @@ import sys
 import json
 import datetime
 
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import UnicodeDictReader
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import UnicodeDictReader
+from memacs.lib.orgproperty import OrgProperties
 
 
 class Csv(Memacs):

--- a/memacs/example.py
+++ b/memacs/example.py
@@ -4,9 +4,9 @@
 
 import logging
 import time
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class Foo(Memacs):

--- a/memacs/filenametimestamps.py
+++ b/memacs/filenametimestamps.py
@@ -3,10 +3,10 @@
 # Time-stamp: <2014-03-13 17:32:22 karl.voit>
 
 import os
-from .lib.memacs import Memacs
-from .lib.orgformat import OrgFormat
-from .lib.orgformat import TimestampParseException
-from .lib.orgproperty import OrgProperties
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.orgformat import TimestampParseException
+from memacs.lib.orgproperty import OrgProperties
 import re
 import logging
 import time

--- a/memacs/firefox.py
+++ b/memacs/firefox.py
@@ -8,9 +8,9 @@ import sys
 import os
 import re
 
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class Firefox(Memacs):

--- a/memacs/git.py
+++ b/memacs/git.py
@@ -6,9 +6,9 @@ import sys
 import os
 import logging
 import time
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class Commit(object):

--- a/memacs/gpx.py
+++ b/memacs/gpx.py
@@ -11,9 +11,9 @@ import gpxpy
 import gpxpy.gpx
 import geocoder
 
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class GPX(Memacs):

--- a/memacs/ical.py
+++ b/memacs/ical.py
@@ -6,10 +6,10 @@ import sys
 import os
 import logging
 import time
-from .lib.memacs import Memacs
-from .lib.orgformat import OrgFormat
-from .lib.orgproperty import OrgProperties
-from .lib.reader import CommonReader
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
 
 try:
     from icalendar import Calendar

--- a/memacs/imap.py
+++ b/memacs/imap.py
@@ -6,8 +6,8 @@ import sys
 import os
 import logging
 import imaplib
-from .lib.memacs import Memacs
-from .lib.mailparser import MailParser
+from memacs.lib.memacs import Memacs
+from memacs.lib.mailparser import MailParser
 
 
 class ImapMemacs(Memacs):

--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -8,9 +8,9 @@ import sys
 
 import pylast
 
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class LastFM(Memacs):

--- a/memacs/mu.py
+++ b/memacs/mu.py
@@ -3,9 +3,9 @@
 
 import subprocess
 from datetime import datetime
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 import re
 
 class MuMail(Memacs):

--- a/memacs/phonecalls.py
+++ b/memacs/phonecalls.py
@@ -8,10 +8,10 @@ import logging
 import xml.sax
 import time, datetime
 from xml.sax._exceptions import SAXParseException
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
+from memacs.lib.orgproperty import OrgProperties
 #import pdb
 
 class PhonecallsSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/phonecalls_superbackup.py
+++ b/memacs/phonecalls_superbackup.py
@@ -8,10 +8,10 @@ import logging
 import xml.sax
 import time, datetime
 from xml.sax._exceptions import SAXParseException
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
+from memacs.lib.orgproperty import OrgProperties
 #import pdb
 
 logging.basicConfig(filename='debug.log', level=logging.DEBUG)

--- a/memacs/photos.py
+++ b/memacs/photos.py
@@ -5,9 +5,9 @@
 import os
 import logging
 import time
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 import imghdr
 from PIL import Image
 from PIL.ExifTags import TAGS

--- a/memacs/rss.py
+++ b/memacs/rss.py
@@ -9,10 +9,10 @@ import feedparser
 import calendar
 import time
 import re
-from .lib.reader import CommonReader
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
 
 
 class RssMemacs(Memacs):

--- a/memacs/simplephonelogs.py
+++ b/memacs/simplephonelogs.py
@@ -8,10 +8,10 @@ import os
 import re
 import time
 
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
+from memacs.lib.orgproperty import OrgProperties
 
 
 class SimplePhoneLogsMemacs(Memacs):

--- a/memacs/sms.py
+++ b/memacs/sms.py
@@ -12,11 +12,11 @@ import codecs      ## Unicode conversion
 import html.parser  ## un-escaping HTML entities like emojis
 import tempfile    ## create temporary files
 from xml.sax._exceptions import SAXParseException
-from .lib.orgformat import OrgFormat
-from .lib.orgproperty import OrgProperties
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
-from .lib.contactparser import parse_org_contact_file
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
+from memacs.lib.contactparser import parse_org_contact_file
 
 
 class SmsSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/sms_superbackup.py
+++ b/memacs/sms_superbackup.py
@@ -8,10 +8,10 @@ import logging
 import xml.sax
 import time
 from xml.sax._exceptions import SAXParseException
-from .lib.orgformat import OrgFormat
-from .lib.orgproperty import OrgProperties
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
 
 
 class SmsSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/svn.py
+++ b/memacs/svn.py
@@ -7,10 +7,10 @@ import os
 import logging
 import xml.sax
 from xml.sax._exceptions import SAXParseException
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import CommonReader
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import CommonReader
 
 
 class SvnSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/twitter.py
+++ b/memacs/twitter.py
@@ -9,10 +9,10 @@ from dateutil import parser
 import os
 import sys
 from twython import Twython, TwythonError
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.reader import UnicodeCsvReader
-from .lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.reader import UnicodeCsvReader
+from memacs.lib.orgproperty import OrgProperties
 
 class Twitter(Memacs):
     def _main(self):

--- a/memacs/whatsapp.py
+++ b/memacs/whatsapp.py
@@ -13,10 +13,10 @@ import re
 
 import emoji
 
-from .lib.orgproperty import OrgProperties
-from .lib.orgformat import OrgFormat
-from .lib.memacs import Memacs
-from .lib.contactparser import parse_org_contact_file
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgformat import OrgFormat
+from memacs.lib.memacs import Memacs
+from memacs.lib.contactparser import parse_org_contact_file
 
 class WhatsApp(Memacs):
 


### PR DESCRIPTION
As mentioned in https://github.com/novoid/Memacs/issues/89 I changed the imports to absolute imports.

Additionally I changed some things in the chrome module to make it ready for python3.
I removed two lines which are connected with utf-8 but their use is highly discouraged.

Therefore it would be nice if someone could test the chrome module