### PR TITLE
Fix chrome.py output to include url and title for org headings.

### DIFF
--- a/memacs/chrome.py
+++ b/memacs/chrome.py
@@ -61,7 +61,7 @@ class Chrome(Memacs):
             properties.add('URL', params['url'])
             properties.add('VISIT_COUNT', params['visit_count'])
 
-        output = ""
+            output = OrgFormat.link(params['url'], params['title'])
         try:
             output = self._args.output_format.decode('utf-8').format(**params)
         except Exception:

--- a/memacs/chrome.py
+++ b/memacs/chrome.py
@@ -61,7 +61,7 @@ class Chrome(Memacs):
             properties.add('URL', params['url'])
             properties.add('VISIT_COUNT', params['visit_count'])
 
-            output = OrgFormat.link(params['url'], params['title'])
+        output = OrgFormat.link(params['url'], params['title'])
         try:
             output = self._args.output_format.decode('utf-8').format(**params)
         except Exception:


### PR DESCRIPTION
Related to Issue #87 

Fixed how the `output` variable formats org-headings in function `handle_url()`.