### PR TITLE
Fix example provided in memacs_chrome_history.org

### DIFF
--- a/docs/memacs_chrome_history.org
+++ b/docs/memacs_chrome_history.org
@@ -16,7 +16,7 @@ We can use Memacs_chrome to generate a file with the datetimes of the urls:
 
 ** Example Invocation
 *** Example with rev-list file:
-: python bin/memacs_chrome.py -f "/home/bala/.config/google-chrome/Default/History" >~/org/chromehist.org_archive
+: python bin/memacs_chrome.py -f "/home/bala/.config/google-chrome/Default/History" -o /org/chromehist.org_archive
 
 ** Example Orgmode entries
 

--- a/docs/memacs_chrome_history.org
+++ b/docs/memacs_chrome_history.org
@@ -16,7 +16,7 @@ We can use Memacs_chrome to generate a file with the datetimes of the urls:
 
 ** Example Invocation
 *** Example with rev-list file:
-: python bin/memacs_chrome.py -f "/home/bala/.config/google-chrome/Default/History" -o /org/chromehist.org_archive
+: python bin/memacs_chrome.py -f "/home/bala/.config/google-chrome/Default/History" -o ~/org/chromehist.org_archive
 
 ** Example Orgmode entries
 


### PR DESCRIPTION
When using the `> output_archive` it creates a leading whitespace character to each of the headings causing the headings to not show up in org-agenda.

Using the --output flag correctly outputs an org-mode file as shown in the example.