### PR TITLE
build: using extras_require and console_script entry point

### DIFF
--- a/bin/memacs_arbtt.py
+++ b/bin/memacs_arbtt.py
@@ -17,7 +17,8 @@ COPYRIGHT_YEAR = "2017"
 COPYRIGHT_AUTHORS = """Manuel Koell <mankoell@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Arbtt(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -26,5 +27,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_battery.py
+++ b/bin/memacs_battery.py
@@ -12,7 +12,8 @@ PROG_TAG = "battery"
 COPYRIGHT_YEAR = "2017"
 COPYRIGHT_AUTHORS = """Manuel Koell <mankoell@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
     memacs = Battery(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -22,3 +23,7 @@ if __name__ == "__main__":
         copyright_authors=COPYRIGHT_AUTHORS
     )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_chrome.py
+++ b/bin/memacs_chrome.py
@@ -19,7 +19,8 @@ COPYRIGHT_YEAR = "2018"
 COPYRIGHT_AUTHORS = """Bala Ramadurai <bala@balaramadurai.net>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Chrome(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -28,6 +29,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-#       use_config_parser_name=CONFIG_PARSER_NAME
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_csv.py
+++ b/bin/memacs_csv.py
@@ -20,7 +20,8 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Csv(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -29,6 +30,10 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-#       use_config_parser_name=CONFIG_PARSER_NAME
-        )
+        # use_config_parser_name=CONFIG_PARSER_NAME
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_example.py
+++ b/bin/memacs_example.py
@@ -29,7 +29,8 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Foo(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -38,6 +39,10 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-#       use_config_parser_name=CONFIG_PARSER_NAME
-        )
+        # use_config_parser_name=CONFIG_PARSER_NAME
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_filenametimestamps.py
+++ b/bin/memacs_filenametimestamps.py
@@ -27,8 +27,9 @@ COPYRIGHT_YEAR = "2011 and higher"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
 
+def main():
+    global memacs
     memacs = FileNameTimeStamps(prog_version=PROG_VERSION_NUMBER,
                                 prog_version_date=PROG_VERSION_DATE,
                                 prog_description=PROG_DESCRIPTION,
@@ -37,3 +38,7 @@ if __name__ == "__main__":
                                 copyright_year=COPYRIGHT_YEAR,
                                 copyright_authors=COPYRIGHT_AUTHORS)
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_firefox.py
+++ b/bin/memacs_firefox.py
@@ -19,7 +19,8 @@ COPYRIGHT_YEAR = "2018"
 COPYRIGHT_AUTHORS = """Raimon Grau <raimonster@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Firefox(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -28,6 +29,10 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-#       use_config_parser_name=CONFIG_PARSER_NAME
-        )
+        # use_config_parser_name=CONFIG_PARSER_NAME
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_git.py
+++ b/bin/memacs_git.py
@@ -23,7 +23,8 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = GitMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -32,5 +33,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_gpx.py
+++ b/bin/memacs_gpx.py
@@ -12,7 +12,8 @@ COPYRIGHT_YEAR = "2017"
 COPYRIGHT_AUTHORS = """Manuel Koell <mankoell@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = GPX(prog_version=PROG_VERSION_NUMBER,
                  prog_version_date=PROG_VERSION_DATE,
                  prog_short_description=PROG_SHORT_DESCRIPTION,
@@ -20,3 +21,7 @@ if __name__ == "__main__":
                  copyright_year=COPYRIGHT_YEAR,
                  copyright_authors=COPYRIGHT_AUTHORS)
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_ical.py
+++ b/bin/memacs_ical.py
@@ -16,7 +16,9 @@ COPYRIGHT_YEAR = "2011-2013"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = CalendarMemacs(prog_version=PROG_VERSION_NUMBER,
                             prog_version_date=PROG_VERSION_DATE,
                             prog_description=PROG_DESCRIPTION,
@@ -24,5 +26,9 @@ if __name__ == "__main__":
                             prog_tag=PROG_TAG,
                             copyright_year=COPYRIGHT_YEAR,
                             copyright_authors=COPYRIGHT_AUTHORS
-        )
+                            )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_imap.py
+++ b/bin/memacs_imap.py
@@ -28,7 +28,8 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = ImapMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -38,5 +39,9 @@ if __name__ == "__main__":
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS,
         use_config_parser_name=CONFIG_PARSER_NAME
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_kodi.py
+++ b/bin/memacs_kodi.py
@@ -15,7 +15,8 @@ COPYRIGHT_YEAR = "2018"
 COPYRIGHT_AUTHORS = """Max Beutelspacher <max.beutelspacher@mailbox.org>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Kodi(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -24,6 +25,10 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-#       use_config_parser_name=CONFIG_PARSER_NAME
-        )
+        #       use_config_parser_name=CONFIG_PARSER_NAME
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_lastfm.py
+++ b/bin/memacs_lastfm.py
@@ -14,7 +14,9 @@ PROG_TAG = "lastfm"
 COPYRIGHT_YEAR = "2017"
 COPYRIGHT_AUTHORS = """Manuel Koell <mankoell@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = LastFM(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -25,3 +27,7 @@ if __name__ == "__main__":
         use_config_parser_name=CONFIG_PARSER_NAME
     )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_mumail.py
+++ b/bin/memacs_mumail.py
@@ -16,8 +16,9 @@ COPYRIGHT_YEAR = "2011-2015"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Stephanus Volke <post@stephanus-volke.de>"""
 
-if __name__ == "__main__":
-    
+
+def main():
+    global memacs
     memacs = MuMail(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -27,5 +28,9 @@ if __name__ == "__main__":
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS,
         use_config_parser_name=CONFIG_PARSER_NAME
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_phonecalls.py
+++ b/bin/memacs_phonecalls.py
@@ -30,7 +30,9 @@ COPYRIGHT_YEAR = "2011-2013"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = PhonecallsMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -39,5 +41,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_phonecalls_superbackup.py
+++ b/bin/memacs_phonecalls_superbackup.py
@@ -31,7 +31,9 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>
 Ian Barton <ian@manor-farm.org>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = PhonecallsSuperBackupMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -40,5 +42,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_photos.py
+++ b/bin/memacs_photos.py
@@ -19,7 +19,9 @@ COPYRIGHT_YEAR = "2012-2013"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = PhotosMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -28,5 +30,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_rss.py
+++ b/bin/memacs_rss.py
@@ -33,7 +33,8 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = RssMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -42,5 +43,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_simplephonelogs.py
+++ b/bin/memacs_simplephonelogs.py
@@ -39,7 +39,9 @@ Then an Org-mode file is generated accordingly.
 COPYRIGHT_YEAR = "2013"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = SimplePhoneLogsMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -48,5 +50,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_sms.py
+++ b/bin/memacs_sms.py
@@ -19,7 +19,9 @@ COPYRIGHT_YEAR = "2011-2014"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = SmsMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -28,5 +30,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_sms_superbackup.py
+++ b/bin/memacs_sms_superbackup.py
@@ -20,7 +20,9 @@ COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>
 Ian Barton <ian@manor-farm.org>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = SmsSuperBackupMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -29,5 +31,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_svn.py
+++ b/bin/memacs_svn.py
@@ -29,7 +29,9 @@ COPYRIGHT_YEAR = "2011-2013"
 COPYRIGHT_AUTHORS = """Karl Voit <tools@Karl-Voit.at>,
 Armin Wieser <armin.wieser@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
+    global memacs
     memacs = SvnMemacs(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -38,5 +40,9 @@ if __name__ == "__main__":
         prog_tag=PROG_TAG,
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_twitter.py
+++ b/bin/memacs_twitter.py
@@ -30,7 +30,8 @@ COPYRIGHT_YEAR = "2013"
 COPYRIGHT_AUTHORS = """Ian Barton <ian@manor-farm.org>"""
 
 
-if __name__ == "__main__":
+def main():
+    global memacs
     memacs = Twitter(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -40,5 +41,9 @@ if __name__ == "__main__":
         copyright_year=COPYRIGHT_YEAR,
         copyright_authors=COPYRIGHT_AUTHORS,
         use_config_parser_name=CONFIG_PARSER_NAME
-        )
+    )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/memacs_whatsapp.py
+++ b/bin/memacs_whatsapp.py
@@ -11,7 +11,8 @@ PROG_TAG = "whatsapp"
 COPYRIGHT_YEAR = "2017"
 COPYRIGHT_AUTHORS = """Manuel Koell <mankoell@gmail.com>"""
 
-if __name__ == "__main__":
+
+def main():
     memacs = WhatsApp(
         prog_version=PROG_VERSION_NUMBER,
         prog_version_date=PROG_VERSION_DATE,
@@ -21,3 +22,7 @@ if __name__ == "__main__":
         copyright_authors=COPYRIGHT_AUTHORS
         )
     memacs.handle_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/memacs/arbtt.py
+++ b/memacs/arbtt.py
@@ -2,18 +2,18 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2017-02-07 19:25 manu>
 
-import subprocess
-import distutils.spawn
-import os.path
-import logging
 import calendar
-import time
-import sys
+import distutils.spawn
 import io
+import logging
+import os.path
+import subprocess
+import sys
+import time
 
-from memacs.lib.reader import UnicodeCsvReader
-from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import UnicodeCsvReader
 
 ARBTT_STATS = 'arbtt-stats'
 ARBTT_FORMAT = '%m/%d/%y %H:%M:%S'

--- a/memacs/battery.py
+++ b/memacs/battery.py
@@ -7,10 +7,10 @@ import logging
 import sys
 
 import batinfo
-
-from memacs.lib.orgproperty import OrgProperties
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 ROOT = '/sys/class/power_supply'
 

--- a/memacs/chrome.py
+++ b/memacs/chrome.py
@@ -2,15 +2,15 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:21:42 vk>
 
-import sqlite3
 import datetime
-import sys
 import os
-import re
+import sqlite3
 
-from memacs.lib.orgproperty import OrgProperties
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+
 
 class Chrome(Memacs):
     def _parser_add_arguments(self):

--- a/memacs/csv.py
+++ b/memacs/csv.py
@@ -3,16 +3,17 @@
 # Time-stamp: <2019-11-06 15:22:17 vk>
 
 import argparse
-import logging
-import time
-import sys
-import json
 import datetime
+import json
+import logging
+import sys
+import time
 
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
-from memacs.lib.reader import UnicodeDictReader
 from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import UnicodeDictReader
 
 
 class Csv(Memacs):

--- a/memacs/example.py
+++ b/memacs/example.py
@@ -4,9 +4,11 @@
 
 import logging
 import time
-from memacs.lib.orgproperty import OrgProperties
+
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 class Foo(Memacs):

--- a/memacs/filenametimestamps.py
+++ b/memacs/filenametimestamps.py
@@ -2,15 +2,17 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2020-05-31 19:15:55 vk>
 
-import os
-from memacs.lib.memacs import Memacs
-from orgformat import OrgFormat, TimestampParseException
-from memacs.lib.orgproperty import OrgProperties
-import re
-import logging
-import time
-import sys
 import codecs
+import logging
+import os
+import re
+import sys
+import time
+
+from orgformat import OrgFormat, TimestampParseException
+
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 # Note: here, the day of the month is optional to allow "2019-10
 # foo.txt" as valid ISO datestamp which will be changed to

--- a/memacs/firefox.py
+++ b/memacs/firefox.py
@@ -2,15 +2,14 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:23:20 vk>
 
-import sqlite3
 import datetime
-import sys
 import os
-import re
+import sqlite3
 
-from memacs.lib.orgproperty import OrgProperties
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 class Firefox(Memacs):

--- a/memacs/git.py
+++ b/memacs/git.py
@@ -2,13 +2,15 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:23:39 vk>
 
-import sys
-import os
 import logging
+import os
+import sys
 import time
-from memacs.lib.orgproperty import OrgProperties
+
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 class Commit(object):

--- a/memacs/gpx.py
+++ b/memacs/gpx.py
@@ -2,18 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import time
-import json
-import sys
 import os
+import time
 
-import gpxpy
-import gpxpy.gpx
 import geocoder
-
-from memacs.lib.orgproperty import OrgProperties
+import gpxpy
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 class GPX(Memacs):

--- a/memacs/ical.py
+++ b/memacs/ical.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-05 16:01:05 vk>
 
-import sys
-import os
 import logging
+import os
+import sys
 import time
-from memacs.lib.memacs import Memacs
+
 from orgformat import OrgFormat
+
+from memacs.lib.memacs import Memacs
 from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.reader import CommonReader
 

--- a/memacs/imap.py
+++ b/memacs/imap.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2012-09-06 19:54:04 armin>
 
-import sys
-import os
-import logging
 import imaplib
-from memacs.lib.memacs import Memacs
+import logging
+import sys
+
 from memacs.lib.mailparser import MailParser
+from memacs.lib.memacs import Memacs
 
 
 class ImapMemacs(Memacs):

--- a/memacs/kodi.py
+++ b/memacs/kodi.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import sys
-import argparse
+import datetime
 import json
 import logging
+import sys
 import time
-import csv
-import datetime
-from memacs.lib.orgproperty import OrgProperties
+from itertools import tee, islice, chain
+
 from orgformat import OrgFormat
-from memacs.lib.memacs import Memacs
+
+from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.reader import UnicodeDictReader
 from .csv import Csv
-
-from itertools import tee, islice, chain
 
 
 # stolen from https://stackoverflow.com/questions/1011938/python-previous-and-next-values-inside-a-loop/1012089#1012089

--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import time
 import datetime
 import logging
 import sys
 
 import pylast
-
-from memacs.lib.orgproperty import OrgProperties
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 class LastFM(Memacs):

--- a/memacs/lib/argparser.py
+++ b/memacs/lib/argparser.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2014-01-28 16:17:20 vk>
 
-from argparse import ArgumentParser
-from argparse import RawDescriptionHelpFormatter
 import os
 import re
+from argparse import ArgumentParser
+from argparse import RawDescriptionHelpFormatter
+
 
 class MemacsArgumentParser(ArgumentParser):
     """

--- a/memacs/lib/contactparser.py
+++ b/memacs/lib/contactparser.py
@@ -1,5 +1,6 @@
-import re
 import logging
+import re
+
 
 def parse_org_contact_file(orgfile):
     """

--- a/memacs/lib/loggingsettings.py
+++ b/memacs/lib/loggingsettings.py
@@ -2,8 +2,8 @@
 # Time-stamp: <2012-05-30 18:19:27 armin>
 
 import logging
-import sys
 import os
+import sys
 
 
 def handle_logging(args,

--- a/memacs/lib/mailparser.py
+++ b/memacs/lib/mailparser.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:24:33 vk>
 
-import time
 import logging
+import time
 from email import message_from_string
-from email.utils import parsedate
 from email.header import decode_header
-from .orgproperty import OrgProperties
+from email.utils import parsedate
+
 from orgformat import OrgFormat
+
+from .orgproperty import OrgProperties
 
 
 class MailParser(object):

--- a/memacs/lib/memacs.py
+++ b/memacs/lib/memacs.py
@@ -3,12 +3,13 @@
 # Time-stamp: <2014-01-28 16:19:18 vk>
 
 import logging
-import traceback
-from .argparser import MemacsArgumentParser
-from .orgwriter import OrgOutputWriter
-from .loggingsettings import handle_logging
 import sys
+import traceback
 from configparser import ConfigParser
+
+from .argparser import MemacsArgumentParser
+from .loggingsettings import handle_logging
+from .orgwriter import OrgOutputWriter
 
 
 class Memacs(object):

--- a/memacs/lib/orgwriter.py
+++ b/memacs/lib/orgwriter.py
@@ -2,14 +2,16 @@
 # Time-stamp: <2019-11-06 15:32:26 vk>
 
 import codecs
-import sys
-import time
+import logging
 import os
 import re
-import logging
+import sys
+import time
+
+from orgformat import OrgFormat
+
 from .orgproperty import OrgProperties
 from .reader import CommonReader
-from orgformat import OrgFormat
 
 
 class OrgOutputWriter(object):

--- a/memacs/lib/reader.py
+++ b/memacs/lib/reader.py
@@ -2,13 +2,13 @@
 # Time-stamp: <2012-05-24 19:08:10 armin>
 
 import codecs
+import csv
 import logging
 import sys
-import csv
 from collections import OrderedDict
-from urllib.request import urlopen
 from urllib.error import HTTPError
 from urllib.error import URLError
+from urllib.request import urlopen
 
 
 class CommonReader:

--- a/memacs/lib/tests/mailparser_test.py
+++ b/memacs/lib/tests/mailparser_test.py
@@ -2,6 +2,7 @@
 # Time-stamp: <2011-12-30 12:16:47 armin>
 
 import unittest
+
 from memacs.lib.mailparser import MailParser
 
 

--- a/memacs/lib/tests/orgproperty_test.py
+++ b/memacs/lib/tests/orgproperty_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:24:56 vk>
 
-import unittest
 import time
+import unittest
+
 from orgformat import OrgFormat
+
 from memacs.lib.orgproperty import OrgProperties
 
 

--- a/memacs/lib/tests/orgwriter_test.py
+++ b/memacs/lib/tests/orgwriter_test.py
@@ -4,13 +4,14 @@
 
 import codecs
 import shutil
-import time
 import tempfile
+import time
 import unittest
 
 from orgformat import OrgFormat
-from memacs.lib.orgwriter import OrgOutputWriter
+
 from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.orgwriter import OrgOutputWriter
 
 
 class TestOutputWriter(unittest.TestCase):

--- a/memacs/lib/tests/reader_test.py
+++ b/memacs/lib/tests/reader_test.py
@@ -2,6 +2,7 @@
 # Time-stamp: <2011-12-30 12:16:47 armin>
 
 import unittest
+
 from memacs.lib.reader import CommonReader
 
 

--- a/memacs/mu.py
+++ b/memacs/mu.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import subprocess
 import locale
-from datetime import datetime
-from memacs.lib.orgproperty import OrgProperties
-from orgformat import OrgFormat
-from memacs.lib.memacs import Memacs
 import re
+import subprocess
+from datetime import datetime
+
+from orgformat import OrgFormat
+
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 # Sets this script's locale to be the same as system locale
 locale.setlocale(locale.LC_TIME, '')

--- a/memacs/phonecalls.py
+++ b/memacs/phonecalls.py
@@ -2,16 +2,21 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:26:05 vk>
 
-import sys
-import os
+import datetime
 import logging
+import os
+import sys
+import time
 import xml.sax
-import time, datetime
-from xml.sax._exceptions import SAXParseException
+
 from orgformat import OrgFormat
+from xml.sax._exceptions import SAXParseException
+
 from memacs.lib.memacs import Memacs
-from memacs.lib.reader import CommonReader
 from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
+
+
 #import pdb
 
 class PhonecallsSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/phonecalls_superbackup.py
+++ b/memacs/phonecalls_superbackup.py
@@ -2,16 +2,20 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:26:30 vk>
 
-import sys
-import os
+import datetime
 import logging
+import os
+import sys
+import time
 import xml.sax
-import time, datetime
-from xml.sax._exceptions import SAXParseException
+
 from orgformat import OrgFormat
+from xml.sax._exceptions import SAXParseException
+
 from memacs.lib.memacs import Memacs
-from memacs.lib.reader import CommonReader
 from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
+
 #import pdb
 
 logging.basicConfig(filename='debug.log', level=logging.DEBUG)

--- a/memacs/photos.py
+++ b/memacs/photos.py
@@ -2,15 +2,17 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:26:47 vk>
 
-import os
-import logging
-import time
-from orgformat import OrgFormat
-from memacs.lib.memacs import Memacs
-from memacs.lib.orgproperty import OrgProperties
 import imghdr
+import logging
+import os
+import time
+
 from PIL import Image
 from PIL.ExifTags import TAGS
+from orgformat import OrgFormat
+
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 
 
 def get_exif_datetime(filename):

--- a/memacs/rss.py
+++ b/memacs/rss.py
@@ -2,17 +2,19 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:27:12 vk>
 
-import sys
-import os
-import logging
-import feedparser
 import calendar
-import time
+import logging
+import os
 import re
-from memacs.lib.reader import CommonReader
-from memacs.lib.orgproperty import OrgProperties
+import sys
+import time
+
+import feedparser
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
 
 
 class RssMemacs(Memacs):

--- a/memacs/simplephonelogs.py
+++ b/memacs/simplephonelogs.py
@@ -9,9 +9,10 @@ import re
 import time
 
 from orgformat import OrgFormat
+
 from memacs.lib.memacs import Memacs
-from memacs.lib.reader import CommonReader
 from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
 
 
 class SimplePhoneLogsMemacs(Memacs):

--- a/memacs/sms.py
+++ b/memacs/sms.py
@@ -2,21 +2,22 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:27:28 vk>
 
-import sys
-import os
-import logging
-import xml.sax
-import time
-import re          ## RegEx for detecting patterns
-import codecs      ## Unicode conversion
+import codecs  ## Unicode conversion
 import html.parser  ## un-escaping HTML entities like emojis
-import tempfile    ## create temporary files
-from xml.sax._exceptions import SAXParseException
+import logging
+import os
+import sys
+import tempfile  ## create temporary files
+import time
+import xml.sax
+
 from orgformat import OrgFormat
-from memacs.lib.orgproperty import OrgProperties
-from memacs.lib.memacs import Memacs
-from memacs.lib.reader import CommonReader
+from xml.sax._exceptions import SAXParseException
+
 from memacs.lib.contactparser import parse_org_contact_file
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+from memacs.lib.reader import CommonReader
 
 
 class SmsSaxHandler(xml.sax.handler.ContentHandler):

--- a/memacs/sms_superbackup.py
+++ b/memacs/sms_superbackup.py
@@ -2,15 +2,17 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:27:45 vk>
 
-import sys
-import os
 import logging
-import xml.sax
+import os
+import sys
 import time
-from xml.sax._exceptions import SAXParseException
+import xml.sax
+
 from orgformat import OrgFormat
-from memacs.lib.orgproperty import OrgProperties
+from xml.sax._exceptions import SAXParseException
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.reader import CommonReader
 
 

--- a/memacs/svn.py
+++ b/memacs/svn.py
@@ -2,14 +2,16 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:28:04 vk>
 
-import sys
-import os
 import logging
+import os
+import sys
 import xml.sax
-from xml.sax._exceptions import SAXParseException
-from memacs.lib.orgproperty import OrgProperties
+
 from orgformat import OrgFormat
+from xml.sax._exceptions import SAXParseException
+
 from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
 from memacs.lib.reader import CommonReader
 
 

--- a/memacs/tests/arbtt_test.py
+++ b/memacs/tests/arbtt_test.py
@@ -2,8 +2,8 @@
 # Time-stamp: <2011-10-28 15:13:31>
 
 import os
-import time
 import unittest
+
 from memacs.arbtt import Arbtt
 
 

--- a/memacs/tests/battery_test.py
+++ b/memacs/tests/battery_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import os
+import unittest
 
 from memacs.battery import Battery
 

--- a/memacs/tests/csv_test.py
+++ b/memacs/tests/csv_test.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2011-10-28 15:13:31 aw>
 
-import unittest
 import os
+import unittest
+
 from memacs.csv import Csv
+
 
 class TestCsv(unittest.TestCase):
 

--- a/memacs/tests/example_test.py
+++ b/memacs/tests/example_test.py
@@ -2,6 +2,7 @@
 # Time-stamp: <2018-08-25 14:16:04 vk>
 
 import unittest
+
 from memacs.example import Foo
 
 

--- a/memacs/tests/filenametimestamps_test.py
+++ b/memacs/tests/filenametimestamps_test.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-10-09 15:12:44 vk>
 
+import datetime
 import os
 import shutil
 import tempfile
 import unittest
-import datetime
 
 from memacs.filenametimestamps import FileNameTimeStamps
 

--- a/memacs/tests/git_test.py
+++ b/memacs/tests/git_test.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2011-10-28 15:13:31 aw>
 
-import unittest
 import os
-from memacs.git import GitMemacs
+import unittest
+
 from memacs.git import Commit
+from memacs.git import GitMemacs
 
 
 class TestCommit(unittest.TestCase):

--- a/memacs/tests/gpx_test.py
+++ b/memacs/tests/gpx_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import os
+import unittest
 
 from memacs.gpx import GPX
 

--- a/memacs/tests/ical_test.py
+++ b/memacs/tests/ical_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2016-01-23 18:07:46 vk>
 
-import unittest
 import os
+import unittest
+
 from memacs.ical import CalendarMemacs
 
 

--- a/memacs/tests/kodi_test.py
+++ b/memacs/tests/kodi_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import unittest
-from memacs.kodi import Kodi
 import os
+import unittest
+
+from memacs.kodi import Kodi
 
 
 class TestKodi(unittest.TestCase):

--- a/memacs/tests/phonecalls_superbackup_test.py
+++ b/memacs/tests/phonecalls_superbackup_test.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 import os
+import unittest
+
 from memacs.phonecalls_superbackup import PhonecallsSuperBackupMemacs
 
 

--- a/memacs/tests/photos_test.py
+++ b/memacs/tests/photos_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2014-05-03 17:46:44 vk>
 
-import unittest
 import os
+import unittest
+
 from memacs.photos import PhotosMemacs
 
 

--- a/memacs/tests/rss_test.py
+++ b/memacs/tests/rss_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2018-08-25 14:44:23 vk>
 
-import unittest
 import os
+import unittest
+
 from memacs.rss import RssMemacs
 
 

--- a/memacs/tests/simplephonelogs_test.py
+++ b/memacs/tests/simplephonelogs_test.py
@@ -7,8 +7,9 @@ import shutil
 import tempfile
 import unittest
 
-from memacs.simplephonelogs import SimplePhoneLogsMemacs
 from memacs.lib.reader import CommonReader
+from memacs.simplephonelogs import SimplePhoneLogsMemacs
+
 
 ## FIXXME: (Note) These test are *not* exhaustive unit tests. They only
 ##         show the usage of the methods. Please add "mean" test cases and

--- a/memacs/tests/svn_test.py
+++ b/memacs/tests/svn_test.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2018-08-26 21:40:32 vk>
 
-import unittest
 import os
+import unittest
+
 from memacs.svn import SvnMemacs
 
 

--- a/memacs/tests/whatsapp_test.py
+++ b/memacs/tests/whatsapp_test.py
@@ -2,7 +2,6 @@
 # Time-stamp: <2018-09-22 13:57:41 vk>
 
 import os
-import time
 import unittest
 
 from memacs.whatsapp import WhatsApp

--- a/memacs/twitter.py
+++ b/memacs/twitter.py
@@ -3,16 +3,15 @@
 # Time-stamp: <2019-11-06 15:28:28 vk>
 
 import logging
-import time
-from datetime import datetime
-from dateutil import parser
-import os
 import sys
-from twython import Twython, TwythonError
+
+from dateutil import parser
 from orgformat import OrgFormat
+from twython import Twython, TwythonError
+
 from memacs.lib.memacs import Memacs
-from memacs.lib.reader import UnicodeCsvReader
 from memacs.lib.orgproperty import OrgProperties
+
 
 class Twitter(Memacs):
     def _main(self):

--- a/memacs/whatsapp.py
+++ b/memacs/whatsapp.py
@@ -2,21 +2,20 @@
 # -*- coding: utf-8 -*-
 # Time-stamp: <2019-11-06 15:29:12 vk>
 
-import sqlite3
-import logging
 import datetime
 import json
-import time
-import sys
+import logging
 import os
 import re
+import sqlite3
 
 import emoji
-
-from memacs.lib.orgproperty import OrgProperties
 from orgformat import OrgFormat
-from memacs.lib.memacs import Memacs
+
 from memacs.lib.contactparser import parse_org_contact_file
+from memacs.lib.memacs import Memacs
+from memacs.lib.orgproperty import OrgProperties
+
 
 class WhatsApp(Memacs):
 

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,27 @@
-# from distutils.core import setup
-
-# Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-# To use a consistent encoding
-# from codecs import open
-from os import path
 
-# workaround from https://github.com/pypa/setuptools/issues/308 to avoid "normalizing" version "2018.01.09" to "2018.1.9":
-# import pkg_resources
-# pkg_resources.extern.packaging.version.Version = pkg_resources.SetuptoolsLegacyVersion
-# 2019-10-02: this is causing "AttributeError: module 'pkg_resources' has no attribute 'SetuptoolsLegacyVersion'"
-#             -> this trick is no longer working
-
-here = path.abspath(path.dirname(__file__))
-
-# Get the long description from the README file
-#with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-#    long_description = f.read()
+# building extra requirements with "all" option to install everything at once
+extras_require = {
+    "gps": ["gpxpy", "geocoder"],
+    "rss": ["feedparser"],
+    "ical": ["icalendar"],
+    "lastfm": ["pylast"],
+    "battery": ["batinfo"],
+    "twitter": ["python-dateutil", "twython"],
+}
+extras_require["all"] = {r for v in extras_require.values() for r in v}
 
 setup(
     name="memacs",
     version="2019.11.06.1",
-    description="Visualize your (digital) life in Emacs Org mode by converting data to Org mode format",
+    description="Visualize your (digital) life in Emacs Org mode "
+                "by converting data to Org mode format",
     author="Karl Voit",
     author_email="tools@Karl-Voit.at",
     url="https://github.com/novoid/memacs",
     download_url="https://github.com/novoid/memacs/zipball/master",
     keywords=["quantified self", "emacs", "org-mode", "org mode"],
-    packages=find_packages(), # Required
-    scripts = [
-        "bin/memacs_arbtt.py","bin/memacs_battery.py","bin/memacs_chrome.py","bin/memacs_csv.py","bin/memacs_example.py","bin/memacs_filenametimestamps.py","bin/memacs_firefox.py","bin/memacs_git.py","bin/memacs_gpx.py","bin/memacs_ical.py","bin/memacs_imap.py","bin/memacs_kodi.py","bin/memacs_lastfm.py","bin/memacs_mumail.py","bin/memacs_phonecalls.py","bin/memacs_phonecalls_superbackup.py","bin/memacs_photos.py","bin/memacs_rss.py","bin/memacs_simplephonelogs.py","bin/memacs_sms.py","bin/memacs_sms_superbackup.py","bin/memacs_svn.py","bin/memacs_twitter.py","bin/memacs_whatsapp.py"],
-    #package_data={},
-    #install_requires=[FIXXME],  # 2019-10-02 Karl: unsure, if it is feasible to add all requirements since there are lots of independent modules ...
+    packages=find_packages(),  # Required
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "Development Status :: 5 - Production/Stable",
@@ -39,13 +29,38 @@ setup(
         "Intended Audience :: End Users/Desktop",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
+    ],
+    # package_data={},
+    install_requires=["orgformat", "emoji"],
+    extras_require=extras_require,
+    entry_points={
+        'console_scripts': [
+            "memacs_arbtt=bin.memacs_arbtt:main",
+            "memacs_battery=bin.memacs_battery:main [battery]",
+            "memacs_chrome=bin.memacs_chrome:main",
+            "memacs_csv=bin.memacs_csv:main",
+            "memacs_example=bin.memacs_example:main",
+            "memacs_filenametimestamps=bin.memacs_filenametimestamps:main",
+            "memacs_firefox=bin.memacs_firefox:main",
+            "memacs_git=bin.memacs_git:main",
+            "memacs_gpx=bin.memacs_gpx:main [gps]",
+            "memacs_ical=bin.memacs_ical:main [ical]",
+            "memacs_imap=bin.memacs_imap:main",
+            "memacs_kodi=bin.memacs_kodi:main",
+            "memacs_lastfm=bin.memacs_lastfm:main [lastfm]",
+            "memacs_mumail=bin.memacs_mumail:main",
+            "memacs_phonecalls=bin.memacs_phonecalls:main",
+            "memacs_phonecalls_superbackup=bin.memacs_phonecalls_superbackup:main",
+            "memacs_photos=bin.memacs_photos:main",
+            "memacs_rss=bin.memacs_rss:main [rss]",
+            "memacs_simplephonelogs=bin.memacs_simplephonelogs:main",
+            "memacs_sms=bin.memacs_sms:main",
+            "memacs_sms_superbackup=bin.memacs_sms_superbackup:main",
+            "memacs_svn=bin.memacs_svn:main",
+            "memacs_twitter=bin.memacs_twitter:main [twitter]",
+            "memacs_whatsapp=bin.memacs_whatsapp:main",
         ],
-    #entry_points={  # Optional   # 2019-10-02 Karl: unsure, if it is feasible to add all entry_points since there are lots of independent modules ...
-    #    'console_scripts': [
-    #       FIXXME
-    #    ],
-    #},
-#    long_description=long_description, # Optional
+     },
     long_description="""This Python framework converts data from various sources to Org mode format
 which may then included in Org mode agenda (calendar). This way, you get a 360-degree-view of your
 digital life.


### PR DESCRIPTION
Dependencies are made optional using setuptools extras_require argument.
Users can now install the package via `pip install memacs[gps,rss]`.
To get all the functionality, use `pip install memacs[all]`
During the dependencies analysis, imports were optimized using pycharm.

Scripts now have a main function that functions as console entry point;
they're now specified as entry_points "console_scripts" to be [cross-platform compatible](https://packaging.python.org/guides/distributing-packages-using-setuptools/?highlight=scripts#scripts).

I also moved from "scripts" to "console_scripts" because [setuptools documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins) states that, after specifying the "extra" required for an entry point,

> an appropriate error message can be displayed if the needed package(s) are missing

Unfortunately I wasn't able to reproduce this behavior, the scripts are all installed and running them doesn't result in the display message.