### PR TITLE
Fixed firefox.py, now org-headings include url and title

### DIFF
--- a/memacs/firefox.py
+++ b/memacs/firefox.py
@@ -55,7 +55,8 @@ class Firefox(Memacs):
             properties.add('URL', params['url'])
             properties.add('VISIT_COUNT', params['visit_count'])
 
-        output = ""
+        output = OrgFormat.link(params['url'], params['title'])
+
         try:
             output = self._args.output_format.decode('utf-8').format(**params)
         except Exception:


### PR DESCRIPTION
Fixed the `output` variable in `firefox.py`, now the default value includes url and title.