### PR TITLE
Correct timezone handling for ical

### DIFF
--- a/memacs/tests/ical_test.py
+++ b/memacs/tests/ical_test.py
@@ -2,6 +2,9 @@
 # Time-stamp: <2016-01-23 18:07:46 vk>
 
 import os
+import re
+import tempfile
+import time
 import unittest
 
 from memacs.ical import CalendarMemacs
@@ -20,7 +23,7 @@ class TestCalendar(unittest.TestCase):
 
         self.assertEqual(
             data[0],
-             "** <2012-05-28 Mon>--<2012-05-28 Mon> Whit Monday")
+             "** <2012-05-28 Mon> Whit Monday")
         self.assertEqual(
             data[1],
              "   :PROPERTIES:")
@@ -32,7 +35,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[4],
-             "** <2011-02-14 Mon>--<2011-02-14 Mon> Valentine's day")
+             "** <2011-02-14 Mon> Valentine's day")
         self.assertEqual(
             data[5],
              "   :PROPERTIES:")
@@ -44,7 +47,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[8],
-             "** <2010-02-14 Sun>--<2010-02-14 Sun> Valentine's day")
+             "** <2010-02-14 Sun> Valentine's day")
         self.assertEqual(
             data[9],
              "   :PROPERTIES:")
@@ -56,7 +59,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[12],
-             "** <2012-02-14 Tue>--<2012-02-14 Tue> Valentine's day")
+             "** <2012-02-14 Tue> Valentine's day")
         self.assertEqual(
             data[13],
              "   :PROPERTIES:")
@@ -68,7 +71,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[16],
-             "** <2012-12-26 Wed>--<2012-12-26 Wed> St. Stephan's Day")
+             "** <2012-12-26 Wed> St. Stephan's Day")
         self.assertEqual(
             data[17],
              "   :PROPERTIES:")
@@ -80,7 +83,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[20],
-             "** <2010-12-26 Sun>--<2010-12-26 Sun> St. Stephan's Day")
+             "** <2010-12-26 Sun> St. Stephan's Day")
         self.assertEqual(
             data[21],
              "   :PROPERTIES:")
@@ -92,7 +95,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[24],
-             "** <2011-12-26 Mon>--<2011-12-26 Mon> St. Stephan's Day")
+             "** <2011-12-26 Mon> St. Stephan's Day")
         self.assertEqual(
             data[25],
              "   :PROPERTIES:")
@@ -104,7 +107,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[28],
-             "** <2011-12-06 Tue>--<2011-12-06 Tue> St. Nicholas")
+             "** <2011-12-06 Tue> St. Nicholas")
         self.assertEqual(
             data[29],
              "   :PROPERTIES:")
@@ -116,7 +119,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[32],
-             "** <2010-12-06 Mon>--<2010-12-06 Mon> St. Nicholas")
+             "** <2010-12-06 Mon> St. Nicholas")
         self.assertEqual(
             data[33],
              "   :PROPERTIES:")
@@ -128,7 +131,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[36],
-             "** <2012-12-06 Thu>--<2012-12-06 Thu> St. Nicholas")
+             "** <2012-12-06 Thu> St. Nicholas")
         self.assertEqual(
             data[37],
              "   :PROPERTIES:")
@@ -140,7 +143,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[40],
-             "** <2011-12-31 Sat>--<2011-12-31 Sat> New Year's Eve")
+             "** <2011-12-31 Sat> New Year's Eve")
         self.assertEqual(
             data[41],
              "   :PROPERTIES:")
@@ -152,7 +155,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[44],
-             "** <2010-12-31 Fri>--<2010-12-31 Fri> New Year's Eve")
+             "** <2010-12-31 Fri> New Year's Eve")
         self.assertEqual(
             data[45],
              "   :PROPERTIES:")
@@ -164,7 +167,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[48],
-             "** <2012-01-01 Sun>--<2012-01-01 Sun> New Year")
+             "** <2012-01-01 Sun> New Year")
         self.assertEqual(
             data[49],
              "   :PROPERTIES:")
@@ -176,7 +179,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[52],
-             "** <2010-01-01 Fri>--<2010-01-01 Fri> New Year")
+             "** <2010-01-01 Fri> New Year")
         self.assertEqual(
             data[53],
              "   :PROPERTIES:")
@@ -188,7 +191,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[56],
-             "** <2011-01-01 Sat>--<2011-01-01 Sat> New Year")
+             "** <2011-01-01 Sat> New Year")
         self.assertEqual(
             data[57],
              "   :PROPERTIES:")
@@ -200,7 +203,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[60],
-             "** <2010-10-26 Tue>--<2010-10-26 Tue> National Holiday")
+             "** <2010-10-26 Tue> National Holiday")
         self.assertEqual(
             data[61],
              "   :PROPERTIES:")
@@ -212,7 +215,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[64],
-             "** <2012-10-26 Fri>--<2012-10-26 Fri> National Holiday")
+             "** <2012-10-26 Fri> National Holiday")
         self.assertEqual(
             data[65],
              "   :PROPERTIES:")
@@ -224,7 +227,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[68],
-             "** <2011-10-26 Wed>--<2011-10-26 Wed> National Holiday")
+             "** <2011-10-26 Wed> National Holiday")
         self.assertEqual(
             data[69],
              "   :PROPERTIES:")
@@ -236,7 +239,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[72],
-             "** <2011-05-01 Sun>--<2011-05-01 Sun> Labour Day")
+             "** <2011-05-01 Sun> Labour Day")
         self.assertEqual(
             data[73],
              "   :PROPERTIES:")
@@ -248,7 +251,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[76],
-             "** <2010-05-01 Sat>--<2010-05-01 Sat> Labour Day")
+             "** <2010-05-01 Sat> Labour Day")
         self.assertEqual(
             data[77],
              "   :PROPERTIES:")
@@ -260,7 +263,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[80],
-             "** <2012-05-01 Tue>--<2012-05-01 Tue> Labour Day")
+             "** <2012-05-01 Tue> Labour Day")
         self.assertEqual(
             data[81],
              "   :PROPERTIES:")
@@ -272,7 +275,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[84],
-             "** <2012-12-08 Sat>--<2012-12-08 Sat> Immaculate Conception")
+             "** <2012-12-08 Sat> Immaculate Conception")
         self.assertEqual(
             data[85],
              "   :PROPERTIES:")
@@ -284,7 +287,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[88],
-             "** <2010-12-08 Wed>--<2010-12-08 Wed> Immaculate Conception")
+             "** <2010-12-08 Wed> Immaculate Conception")
         self.assertEqual(
             data[89],
              "   :PROPERTIES:")
@@ -296,7 +299,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[92],
-             "** <2011-12-08 Thu>--<2011-12-08 Thu> Immaculate Conception")
+             "** <2011-12-08 Thu> Immaculate Conception")
         self.assertEqual(
             data[93],
              "   :PROPERTIES:")
@@ -308,7 +311,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[96],
-             "** <2012-04-06 Fri>--<2012-04-06 Fri> Good Friday")
+             "** <2012-04-06 Fri> Good Friday")
         self.assertEqual(
             data[97],
              "   :PROPERTIES:")
@@ -320,7 +323,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[100],
-             "** <2010-01-06 Wed>--<2010-01-06 Wed> Epiphany")
+             "** <2010-01-06 Wed> Epiphany")
         self.assertEqual(
             data[101],
              "   :PROPERTIES:")
@@ -332,7 +335,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[104],
-             "** <2012-01-06 Fri>--<2012-01-06 Fri> Epiphany")
+             "** <2012-01-06 Fri> Epiphany")
         self.assertEqual(
             data[105],
              "   :PROPERTIES:")
@@ -344,7 +347,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[108],
-             "** <2011-01-06 Thu>--<2011-01-06 Thu> Epiphany")
+             "** <2011-01-06 Thu> Epiphany")
         self.assertEqual(
             data[109],
              "   :PROPERTIES:")
@@ -356,7 +359,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[112],
-             "** <2012-04-09 Mon>--<2012-04-09 Mon> Easter Monday")
+             "** <2012-04-09 Mon> Easter Monday")
         self.assertEqual(
             data[113],
              "   :PROPERTIES:")
@@ -368,7 +371,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[116],
-             "** <2012-04-08 Sun>--<2012-04-08 Sun> Easter")
+             "** <2012-04-08 Sun> Easter")
         self.assertEqual(
             data[117],
              "   :PROPERTIES:")
@@ -380,7 +383,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[120],
-             "** <2012-06-07 Thu>--<2012-06-07 Thu> Corpus Christi")
+             "** <2012-06-07 Thu> Corpus Christi")
         self.assertEqual(
             data[121],
              "   :PROPERTIES:")
@@ -392,7 +395,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[124],
-             "** <2011-12-24 Sat>--<2011-12-24 Sat> Christmas Eve")
+             "** <2011-12-24 Sat> Christmas Eve")
         self.assertEqual(
             data[125],
              "   :PROPERTIES:")
@@ -404,7 +407,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[128],
-             "** <2010-12-24 Fri>--<2010-12-24 Fri> Christmas Eve")
+             "** <2010-12-24 Fri> Christmas Eve")
         self.assertEqual(
             data[129],
              "   :PROPERTIES:")
@@ -416,7 +419,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[132],
-             "** <2012-12-24 Mon>--<2012-12-24 Mon> Christmas Eve")
+             "** <2012-12-24 Mon> Christmas Eve")
         self.assertEqual(
             data[133],
              "   :PROPERTIES:")
@@ -428,7 +431,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[136],
-             "** <2010-12-25 Sat>--<2010-12-25 Sat> Christmas")
+             "** <2010-12-25 Sat> Christmas")
         self.assertEqual(
             data[137],
              "   :PROPERTIES:")
@@ -440,7 +443,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[140],
-             "** <2011-12-25 Sun>--<2011-12-25 Sun> Christmas")
+             "** <2011-12-25 Sun> Christmas")
         self.assertEqual(
             data[141],
              "   :PROPERTIES:")
@@ -452,7 +455,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[144],
-             "** <2012-12-25 Tue>--<2012-12-25 Tue> Christmas")
+             "** <2012-12-25 Tue> Christmas")
         self.assertEqual(
             data[145],
              "   :PROPERTIES:")
@@ -464,7 +467,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[148],
-             "** <2010-08-15 Sun>--<2010-08-15 Sun> Assumption")
+             "** <2010-08-15 Sun> Assumption")
         self.assertEqual(
             data[149],
              "   :PROPERTIES:")
@@ -476,7 +479,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[152],
-             "** <2012-08-15 Wed>--<2012-08-15 Wed> Assumption")
+             "** <2012-08-15 Wed> Assumption")
         self.assertEqual(
             data[153],
              "   :PROPERTIES:")
@@ -488,7 +491,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[156],
-             "** <2011-08-15 Mon>--<2011-08-15 Mon> Assumption")
+             "** <2011-08-15 Mon> Assumption")
         self.assertEqual(
             data[157],
              "   :PROPERTIES:")
@@ -500,7 +503,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[160],
-             "** <2012-05-17 Thu>--<2012-05-17 Thu> Ascension Day")
+             "** <2012-05-17 Thu> Ascension Day")
         self.assertEqual(
             data[161],
              "   :PROPERTIES:")
@@ -512,7 +515,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[164],
-             "** <2011-11-02 Wed>--<2011-11-02 Wed> All Souls' Day")
+             "** <2011-11-02 Wed> All Souls' Day")
         self.assertEqual(
             data[165],
              "   :PROPERTIES:")
@@ -524,7 +527,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[168],
-             "** <2010-11-02 Tue>--<2010-11-02 Tue> All Souls' Day")
+             "** <2010-11-02 Tue> All Souls' Day")
         self.assertEqual(
             data[169],
              "   :PROPERTIES:")
@@ -536,7 +539,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[172],
-             "** <2012-11-02 Fri>--<2012-11-02 Fri> All Souls' Day")
+             "** <2012-11-02 Fri> All Souls' Day")
         self.assertEqual(
             data[173],
              "   :PROPERTIES:")
@@ -548,7 +551,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[176],
-             "** <2010-11-01 Mon>--<2010-11-01 Mon> All Saints' Day")
+             "** <2010-11-01 Mon> All Saints' Day")
         self.assertEqual(
             data[177],
              "   :PROPERTIES:")
@@ -560,7 +563,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[180],
-             "** <2012-11-01 Thu>--<2012-11-01 Thu> All Saints' Day")
+             "** <2012-11-01 Thu> All Saints' Day")
         self.assertEqual(
             data[181],
              "   :PROPERTIES:")
@@ -572,7 +575,7 @@ class TestCalendar(unittest.TestCase):
              "   :END:")
         self.assertEqual(
             data[184],
-             "** <2011-11-01 Tue>--<2011-11-01 Tue> All Saints' Day")
+             "** <2011-11-01 Tue> All Saints' Day")
         self.assertEqual(
             data[185],
              "   :PROPERTIES:")
@@ -583,8 +586,94 @@ class TestCalendar(unittest.TestCase):
             data[187],
              "   :END:")
         self.assertEqual(
-            data[188:194], ['** <2011-08-22 Mon>-<9999-12-31 Fri> No end time/date',
+            data[188:194], ['** <2011-08-22 Mon 16:10>--<9999-12-31 Fri> No end time/date',
                             '   :PROPERTIES:',
                             '   :DESCRIPTION: No end time/date',
                             '   :ID:          62bf353bf19c0379faf4910741635dfd6a804b11',
                             '   :END:'])
+
+    def __build_ical_str(self, dtstart, dtend, extra):
+        if dtend:
+            dtend = "DTEND" + dtend + "\n"
+
+        return ("BEGIN:VCALENDAR\n"
+                "VERSION:2.0\n"
+                "PRODID:manual\n"
+                + (extra or "") +
+                "BEGIN:VEVENT\n"
+                "CLASS:PUBLIC\n"
+                "DTSTART" + dtstart + "\n"
+                + (dtend or "") +
+                "UID:whatever.ics\n"
+                "DTSTAMP:20190127T140400\n"
+                "DESCRIPTION:whatever\n"
+                "SUMMARY:whatever\n"
+                "END:VEVENT\n"
+                "END:VCALENDAR\n")
+
+    # Several variations need to be tested here:
+    #
+    # - DATE-TIME:
+    #   - [1] UTC
+    #   - [2] VTIMEZONE-specifed
+    #   - [3] Inline (IANA-style, w/o VTIMEZONE)*
+    #   - Floating:
+    #     - [4] Basic case (truly floating)
+    #     - [5] w/ X-WR-TIMEZONE*
+    #   - [6] No end DATE-TIME
+    # - DATE:
+    #   - [7] Basic case (differing dates)
+    #   - [8] One-day, all-day event (collapsed to single org timestamp)
+    #   - [9] No end DATE
+    #
+    # * = not included in RFC5545, but commonly in use.
+    def test_date_handling(self):
+        os.environ['TZ'] = "America/Chicago"
+        time.tzset()
+
+        VTIMEZONE_COMPONENT = ("BEGIN:VTIMEZONE\n"
+                               "TZID:My/Berlin\n"
+                               "TZURL:http://tzurl.org/zoneinfo-outlook/Europe/Berlin\n"
+                               "X-LIC-LOCATION:Europe/Berlin\n"
+                               "BEGIN:DAYLIGHT\n"
+                               "TZOFFSETFROM:+0100\n"
+                               "TZOFFSETTO:+0200\n"
+                               "TZNAME:CEST\n"
+                               "DTSTART:19700329T020000\n"
+                               "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\n"
+                               "END:DAYLIGHT\n"
+                               "BEGIN:STANDARD\n"
+                               "TZOFFSETFROM:+0200\n"
+                               "TZOFFSETTO:+0100\n"
+                               "TZNAME:CET\n"
+                               "DTSTART:19701025T030000\n"
+                               "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\n"
+                               "END:STANDARD\n"
+                               "END:VTIMEZONE\n")
+
+        cases = [(':20181103T201500Z',                     ':20181103T211500Z',                    None,                             '<2018-11-03 Sat 15:15>--<2018-11-03 Sat 16:15>'), # [1]
+                 (':20181103T201500Z',                     ':20181103T201500Z',                    None,                             '<2018-11-03 Sat 15:15>--<2018-11-03 Sat 15:15>'), # [1] (no collapse)
+                 (';TZID=My/Berlin:20181103T201500',       ';TZID=My/Berlin:20181103T211500',      VTIMEZONE_COMPONENT,              '<2018-11-03 Sat 14:15>--<2018-11-03 Sat 15:15>'), # [2]
+                 (';TZID=Europe/Berlin:20181103T201500:',  ';TZID=Europe/Berlin:20181103T211500',  None,                             '<2018-11-03 Sat 14:15>--<2018-11-03 Sat 15:15>'), # [3]
+                 (';TZID=Europe/Berlin:20181103T201500',   ';TZID=Europe/Berlin:20181103T211500',  'X-WR-TIMEZONE:America/Denver\n', '<2018-11-03 Sat 14:15>--<2018-11-03 Sat 15:15>'), # [3] (X-WR-TIMEZONE ignored)
+                 (':20181103T201500',                      ':20181103T211500',                     None,                             '<2018-11-03 Sat 20:15>--<2018-11-03 Sat 21:15>'), # [4]
+                 (':20181103T201500',                      ':20181103T211500',                     'X-WR-TIMEZONE:Europe/Berlin\n',  '<2018-11-03 Sat 14:15>--<2018-11-03 Sat 15:15>'), # [5]
+                 (':20181103T201500',                      None,                                   'X-WR-TIMEZONE:Europe/Berlin\n',  '<2018-11-03 Sat 14:15>--<9999-12-31 Fri>'),       # [6]
+                 (':20210201',                             ':20210204',                            None,                             '<2021-02-01 Mon>--<2021-02-03 Wed>'),             # [7]
+                 (':20210201',                             ':20210204',                            'X-WR-TIMEZONE:Europe/Berlin\n',  '<2021-02-01 Mon>--<2021-02-03 Wed>'),             # [7] (X-WR-TIMEZONE ignored)
+                 (':20210201',                             ':20210202',                            'X-WR-TIMEZONE:Europe/Berlin\n',  '<2021-02-01 Mon>'),                               # [8]
+                 (':20210201',                             None,                                   'X-WR-TIMEZONE:Europe/Berlin\n',  '<2021-02-01 Mon>--<9999-12-31 Fri>')]             # [9]
+
+        for (dtstart, dtend, extra, output) in cases:
+            with tempfile.NamedTemporaryFile("wt") as tmp:
+                tmp.write(self.__build_ical_str(dtstart, dtend, extra))
+                tmp.seek(0)
+
+                print("+++ Testing: " + dtstart + " / " + str(dtend) + " / " + str(extra)[:10] + " +++")
+
+                argv = "-s -cf " + tmp.name
+                memacs = CalendarMemacs(argv=argv.split())
+                data = memacs.test_get_entries()
+
+                m = re.search("<.*>", data[0]).group(0)
+                self.assertEqual(output, m)

--- a/memacs/tests/ical_test.py
+++ b/memacs/tests/ical_test.py
@@ -29,7 +29,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[2],
-             "   :ID:         b6972cddd864a2fba79ed8ff95e0f2f8948f2410")
+             "   :ID:         8ba5a253410baff870da60487d97976bae948e6d")
         self.assertEqual(
             data[3],
              "   :END:")
@@ -41,7 +41,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[6],
-             "   :ID:         66186caf3409e2086a9c199a03cb6ff440ab738b")
+             "   :ID:         e5d97f07e8df141cddb101943449afddbc2c4366")
         self.assertEqual(
             data[7],
              "   :END:")
@@ -53,7 +53,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[10],
-             "   :ID:         bee25809ac0695d567664decb61592ada965f858")
+             "   :ID:         7816a7cfdeebd359c435e5da53dbbe15e0902115")
         self.assertEqual(
             data[11],
              "   :END:")
@@ -65,7 +65,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[14],
-             "   :ID:         d74b79979f616f13715439a1ef7e0b2f0c69f220")
+             "   :ID:         e3e1dfc836f4ddb91be7e396001993dc42dac33d")
         self.assertEqual(
             data[15],
              "   :END:")
@@ -77,7 +77,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[18],
-             "   :ID:         c2559692c5465c6dad0f014f936eef320b516b9f")
+             "   :ID:         5f2df9848d632c475e3cf509251f31359828cd19")
         self.assertEqual(
             data[19],
              "   :END:")
@@ -89,7 +89,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[22],
-             "   :ID:         c145ba3f76fab2f9eca5a9b09695c47b1f65554a")
+             "   :ID:         e74c056dfdb5ebcbfd8d725eacf5fe2180204705")
         self.assertEqual(
             data[23],
              "   :END:")
@@ -101,7 +101,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[26],
-             "   :ID:         0c663e887265d372cf40d3c7f1d7fd595a0114a0")
+             "   :ID:         646b8200bd6186fc7c75bac6050486544edf9208")
         self.assertEqual(
             data[27],
              "   :END:")
@@ -113,7 +113,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[30],
-             "   :ID:         821d4ce5231db9f037cf64f8b3cfeeeb65c84bee")
+             "   :ID:         3beb4ee6504aea9042b8a760a4cfdb82b24cb271")
         self.assertEqual(
             data[31],
              "   :END:")
@@ -125,7 +125,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[34],
-             "   :ID:         4b1f7183ef085af82ec9b7be7845d35d9504b0b6")
+             "   :ID:         ee05ddc226cfd7cbde339d25d9983a2e528040a9")
         self.assertEqual(
             data[35],
              "   :END:")
@@ -137,7 +137,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[38],
-             "   :ID:         34c1c44697bedbe3228842204e84f45ec45b0923")
+             "   :ID:         110237aee7b949c84e1c5614f1f7fb631c9ff942")
         self.assertEqual(
             data[39],
              "   :END:")
@@ -149,7 +149,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[42],
-             "   :ID:         ea722a9d474e8bbda41f48460ad3681e10097044")
+             "   :ID:         1a571159635d3d651b6af68d20620eade7f8a984")
         self.assertEqual(
             data[43],
              "   :END:")
@@ -161,7 +161,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[46],
-             "   :ID:         afcbb4912aaede6e31b0c4bdb9221b90f10c1b62")
+             "   :ID:         cc2b9683716ac8d32c381ae9380d0a25f57ae0f5")
         self.assertEqual(
             data[47],
              "   :END:")
@@ -173,7 +173,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[50],
-             "   :ID:         9a533328738c914dcc4abd5bb571e63cccae0fa2")
+             "   :ID:         0b5b288f6b0322e0fae4beed157989d319b82814")
         self.assertEqual(
             data[51],
              "   :END:")
@@ -185,7 +185,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[54],
-             "   :ID:         1239f768e303f38b312d4fa84ad295f44a12ea99")
+             "   :ID:         ab434dc5112a7a5c2237131c71ca254f5f99dc05")
         self.assertEqual(
             data[55],
              "   :END:")
@@ -197,7 +197,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[58],
-             "   :ID:         c578509791f5865707d0018ad79c2eaf37210481")
+             "   :ID:         869198e6dcfa0bc49fc171f17d50ba49d3fe62a7")
         self.assertEqual(
             data[59],
              "   :END:")
@@ -209,7 +209,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[62],
-             "   :ID:         dffe086b45549c333b308892bf7b4b83485ea216")
+             "   :ID:         3c6042aba5db24b2ed09eedc1b3da56e7e0b601f")
         self.assertEqual(
             data[63],
              "   :END:")
@@ -221,7 +221,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[66],
-             "   :ID:         5d74bcc91609435775c774cf4b2c373e3b6b9a9e")
+             "   :ID:         601c8de3cea5d678e9919c9d64b1d7655f7843e5")
         self.assertEqual(
             data[67],
              "   :END:")
@@ -233,7 +233,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[70],
-             "   :ID:         5c99d7709dfe1e81b18e3c3343e06edd0854015f")
+             "   :ID:         2f61fd1f446d4f384f3caf65a404d50b86f696a4")
         self.assertEqual(
             data[71],
              "   :END:")
@@ -245,7 +245,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[74],
-             "   :ID:         5f18bf2bffdedf1fd50bca2b5ccfb8bd7554b52f")
+             "   :ID:         781eb260ac25af31e97c26890f105ef7fdf03635")
         self.assertEqual(
             data[75],
              "   :END:")
@@ -257,7 +257,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[78],
-             "   :ID:         248bbd02f36ba32fbe36c5fdf65ab66a400307c5")
+             "   :ID:         70c5b304f299beac1474dd8bef716d47e1cf15a7")
         self.assertEqual(
             data[79],
              "   :END:")
@@ -269,7 +269,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[82],
-             "   :ID:         709d57b34901a8dab5277cdec884acb989579451")
+             "   :ID:         c3b5e3ed1905b6a8c63847ad5ea12a87108f951f")
         self.assertEqual(
             data[83],
              "   :END:")
@@ -281,7 +281,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[86],
-             "   :ID:         9718f2c669addc152c80d478beaeb81ab7dc2757")
+             "   :ID:         9b716e3e1d58220b301621c6f027e73667ab7b52")
         self.assertEqual(
             data[87],
              "   :END:")
@@ -293,7 +293,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[90],
-             "   :ID:         7d02e0af4e44664e5a474376dd97ba838bcdb725")
+             "   :ID:         b9a77981c516f27a9985223d5af3e578f1d11c3d")
         self.assertEqual(
             data[91],
              "   :END:")
@@ -305,7 +305,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[94],
-             "   :ID:         20e022ce71904efac1f90d45b24b4164623a919b")
+             "   :ID:         4043adda1b297521c55cd06b912de52e1373a999")
         self.assertEqual(
             data[95],
              "   :END:")
@@ -317,7 +317,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[98],
-             "   :ID:         6a9a405cdba496987ca9ab66aef623fe0ed70e26")
+             "   :ID:         344c7600e82efb9445e871b931877d051b94b6c9")
         self.assertEqual(
             data[99],
              "   :END:")
@@ -329,7 +329,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[102],
-             "   :ID:         6640ef7807da042944392601c4e9b046174bce8e")
+             "   :ID:         93ba1d459c22550601fffa38c9204067296a51e1")
         self.assertEqual(
             data[103],
              "   :END:")
@@ -341,7 +341,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[106],
-             "   :ID:         0aa9ab88fb1bfcb9b0fb430e673ec23eb42a4f38")
+             "   :ID:         699f5d8d424735f5593e1d1d44604f529c4fdbb3")
         self.assertEqual(
             data[107],
              "   :END:")
@@ -353,7 +353,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[110],
-             "   :ID:         36897fcbb92a331ebebb86f4cef7b0e988c020c6")
+             "   :ID:         d48ee26b995cb0c2033077c99788ec6cca5afb66")
         self.assertEqual(
             data[111],
              "   :END:")
@@ -365,7 +365,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[114],
-             "   :ID:         a71164883dcb44825f7de50f68b7ea881b1a5d23")
+             "   :ID:         c69c15ca890a76c6c982f7a998ae4c9ce79ddd45")
         self.assertEqual(
             data[115],
              "   :END:")
@@ -377,7 +377,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[118],
-             "   :ID:         7dcfbb563cd9300bf18f3c05965a1b0c7c6442b8")
+             "   :ID:         f0d2b4a8dbcca5208b2aab6755e8cd7c1efe18e5")
         self.assertEqual(
             data[119],
              "   :END:")
@@ -389,7 +389,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[122],
-             "   :ID:         01cd602579e0774b020c3d13a760e8fa828c6aec")
+             "   :ID:         32e659d60f167f7386c8269644c9c920614ce55d")
         self.assertEqual(
             data[123],
              "   :END:")
@@ -401,7 +401,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[126],
-             "   :ID:         4b91f8eefc9723bb3022b2bedb4c4d098f7f9d39")
+             "   :ID:         949f24fdaa8122916bad02b3548e402b2d2391e7")
         self.assertEqual(
             data[127],
              "   :END:")
@@ -413,7 +413,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[130],
-             "   :ID:         b3b00147203e50aa69fdae2f6745b78d13a39231")
+             "   :ID:         96dfd09ae391c0a4e1ecd00ffbc875e714dcf9c6")
         self.assertEqual(
             data[131],
              "   :END:")
@@ -425,7 +425,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[134],
-             "   :ID:         23506451af37175457bfff7b113aff5ff75881e7")
+             "   :ID:         554ab6eebf09552bccc3264f46000f98a3812ab0")
         self.assertEqual(
             data[135],
              "   :END:")
@@ -437,7 +437,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[138],
-             "   :ID:         ae52748d82d25b1ada9ef73e6c608519c0cecca5")
+             "   :ID:         9047b4007e15ff0250613e25650aadb1be5ff8a7")
         self.assertEqual(
             data[139],
              "   :END:")
@@ -449,7 +449,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[142],
-             "   :ID:         802fb8acb3618909a6d7aaf605bf732a97a84d39")
+             "   :ID:         a4e7890b6ce1602706a74fff5a0fc067492dc586")
         self.assertEqual(
             data[143],
              "   :END:")
@@ -461,7 +461,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[146],
-             "   :ID:         1dc9ebe2f8ff2c91ca155c30ae65a67db11cf8aa")
+             "   :ID:         6eee35b32d3d3e172e14528e32c02e7bae48e3fc")
         self.assertEqual(
             data[147],
              "   :END:")
@@ -473,7 +473,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[150],
-             "   :ID:         c3e85e7c44c5cca95efa0751c7c52375640b43c2")
+             "   :ID:         be5c5c89e8e8f98ada9548422b3707fff9d41512")
         self.assertEqual(
             data[151],
              "   :END:")
@@ -485,7 +485,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[154],
-             "   :ID:         52c49d4ca2a196e6409ac362183cedcd656975ef")
+             "   :ID:         71156b8c067eabdea667f8696395011414ab967c")
         self.assertEqual(
             data[155],
              "   :END:")
@@ -497,7 +497,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[158],
-             "   :ID:         be957e5083131794b874b06597cd1cc935d35408")
+             "   :ID:         aaf4f5c9ff6a712b701539baa69d3afede23012c")
         self.assertEqual(
             data[159],
              "   :END:")
@@ -509,7 +509,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[162],
-             "   :ID:         f718e41128812a9864df1a1aa649c23c82f453f9")
+             "   :ID:         e219abf88617f8796c9fba500e3bb9b829dac14a")
         self.assertEqual(
             data[163],
              "   :END:")
@@ -521,7 +521,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[166],
-             "   :ID:         f55d246b411fd4fe3d47205041538d04f56cac53")
+             "   :ID:         1dd09748419fc6f7eee66184febf879f6323a2d5")
         self.assertEqual(
             data[167],
              "   :END:")
@@ -533,7 +533,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[170],
-             "   :ID:         62e1a6c16ce2c40e33d67961b6cec5c0a099b14d")
+             "   :ID:         c7559b4e0501b55eecce604b3939e34683a60fb8")
         self.assertEqual(
             data[171],
              "   :END:")
@@ -545,7 +545,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[174],
-             "   :ID:         c9eae72e34489720698a1054cd03bb4cc8859e71")
+             "   :ID:         581e71732c88e6225a282be86e284002ddd23b97")
         self.assertEqual(
             data[175],
              "   :END:")
@@ -557,7 +557,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[178],
-             "   :ID:         b87bcffe87fda005047d738c07a31cd8c25f609c")
+             "   :ID:         69e6dffd28ba8b5f396fb9ceecf115d0f08a6369")
         self.assertEqual(
             data[179],
              "   :END:")
@@ -569,7 +569,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[182],
-             "   :ID:         37b17e9da936c61a627101afd0cc87d28aafbe70")
+             "   :ID:         554ed843558464e3867d3154d88541a953f23708")
         self.assertEqual(
             data[183],
              "   :END:")
@@ -581,7 +581,7 @@ class TestCalendar(unittest.TestCase):
              "   :PROPERTIES:")
         self.assertEqual(
             data[186],
-             "   :ID:         fe605142ace6ab6268fc672fccece05219c17148")
+             "   :ID:         aa06dce749fe46fabe338df8bee04ecdfa0b120a")
         self.assertEqual(
             data[187],
              "   :END:")
@@ -589,7 +589,7 @@ class TestCalendar(unittest.TestCase):
             data[188:194], ['** <2011-08-22 Mon 16:10>--<9999-12-31 Fri> No end time/date',
                             '   :PROPERTIES:',
                             '   :DESCRIPTION: No end time/date',
-                            '   :ID:          62bf353bf19c0379faf4910741635dfd6a804b11',
+                            '   :ID:          23c8b62cf2043b91627ffb832fa565fc125f95a3',
                             '   :END:'])
 
     def __build_ical_str(self, dtstart, dtend, extra):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ gpxpy
 icalendar
 Pillow
 pylast
+pytz
 twython


### PR DESCRIPTION
Properly handles DATEs and DATE-TIMEs in all formats supported by the iCalendar specification and the X-WR-TIMEZONE convention commonly used by vendors like Google.

DATE-TIMEs are converted to the local timezone when when Memacs runs since org-mode doesn't support timezones.

Additionally:

  - Displays one-day, all-day events with a single Org (date)
    timestamp instead of a range.

  - Fixes incorrect date range with single hyphen when displaying an
    open-ended event specified with a DATE.

  - Fixes silent discarding of start time when displaying an
    open-ended event specified with a DATE-TIME.

  - Adds extensive tests for all DATE / DATE-TIME variations.

  - Makes some effort to preserve existing hash values.