### PR TITLE
fix vulnerable backtracking regular expression

### DIFF
--- a/memacs/lib/contactparser.py
+++ b/memacs/lib/contactparser.py
@@ -24,7 +24,7 @@ def parse_org_contact_file(orgfile):
     contacts = {}
     current_name = ''
 
-    HEADER_REGEX = re.compile('^(\*+)\s+(.*?)(\s+(:\S+:)+)?$')
+    HEADER_REGEX = re.compile('^(\*+)\s+([^\s:]([^:]*)[^\s:])(\s+(:[^\s]+:)+)?')
     PHONE = '\s+([\+\d\-/ ]{7,})$'
     PHONE_REGEX = re.compile(':(PHONE|oldPHONE|MOBILE|oldMOBILE|HOMEPHONE|oldHOMEPHONE|WORKPHONE|oldWORKPHONE):' + PHONE)
 


### PR DESCRIPTION
Should match the same stuff in the org headings without having the vulnerable backtracking regexp

I don't think that the units tests are covering the contact parsing are they?