### PR TITLE
fix: removes the limit from pylast query

### DIFF
--- a/memacs/lastfm.py
+++ b/memacs/lastfm.py
@@ -79,7 +79,7 @@ class LastFM(Memacs):
 
             user = network.get_user(options['username'])
 
-            self._handle_recent_tracks(user.get_recent_tracks(limit=100))
+            self._handle_recent_tracks(user.get_recent_tracks(limit=None))
 
         except pylast.WSError as e:
             logging.error('an issue with the network web service occured: %s' % e)


### PR DESCRIPTION
This PR removes the limit for the pylast queries. The limit does not refer to the official API query limit, just to how many scrobbles we want to parse. The paging gets automatically handle by pylast. 

Tested with my account:
>  successfully parsed 4325 entries by ./bin/memacs_lastfm.py at [2025-03-30 Sun 16:00] in ~52.456570s.

would close #132 